### PR TITLE
chore: merge main into dev to resolve ci.yml conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,15 @@ jobs:
 
       - name: Type check
         run: npx tsc --noEmit
+        continue-on-error: true
 
       - name: Lint
         run: npx eslint . --max-warnings=0
+        continue-on-error: true
 
       - name: Build
         run: npm run build
 
-      - name: Run tests
+      - name: Test
         run: npx vitest run
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Type check
         run: npx tsc --noEmit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,26 +15,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 20
-          cache: npm
+          bun-version: latest
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: bun install
 
       - name: Type check
-        run: npx tsc --noEmit
-        continue-on-error: true
+        run: bun run tsc --noEmit
 
       - name: Lint
-        run: npx eslint . --max-warnings=0
-        continue-on-error: true
+        run: bun run eslint .
 
       - name: Build
-        run: npm run build
+        run: bun run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
 
       - name: Test
-        run: npx vitest run
-        continue-on-error: true
+        run: bun run vitest run
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Welcome to your Lovable project
 
+<!-- CI/CD pipeline test -->
+
 ## Project info
 
 **URL**: https://lovable.dev/projects/REPLACE_WITH_PROJECT_ID


### PR DESCRIPTION
Merge 3 main-only commits into dev to resolve ci.yml conflicts before production merge. The dev version of ci.yml (using Bun, clean config) is the correct one — main's legacy-peer-deps and continue-on-error changes will be superseded.