### PR TITLE
fix: update vercel.json to use Bun instead of npm

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
-  "framework": "vite",
-  "buildCommand": "npm run build",
-  "outputDirectory": "dist",
-  "installCommand": "npm ci",
-  "devCommand": "npm run dev",
-  "regions": ["iad1"]
+    "framework": "vite",
+    "buildCommand": "bun run build",
+    "outputDirectory": "dist",
+    "installCommand": "bun install",
+    "devCommand": "bun run dev",
+    "regions": ["iad1"]
 }


### PR DESCRIPTION
Root cause of ALL Vercel deployment failures: vercel.json had npm ci/npm run build but project uses bun.lock (no package-lock.json). Changed installCommand to bun install, buildCommand to bun run build, devCommand to bun run dev.