### PR TITLE
refactor: reorganize sidebars for all roles

### DIFF
--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -13,20 +13,56 @@ import {
   ScrollText, Layers, Terminal, ClipboardList, LifeBuoy, MessageSquare,
 } from "lucide-react";
 
-const adminNav = [
-  { title: "Command Center", url: "/admin", icon: LayoutDashboard },
-  { title: "Users", url: "/admin/users", icon: Users },
-  { title: "The Crew Status", url: "/admin/agents", icon: Bot },
-  { title: "Agent Runs", url: "/admin/agent-runs", icon: Bot },
-  { title: "Event Log", url: "/admin/logs", icon: ScrollText },
-  { title: "Queue", url: "/admin/queue", icon: Layers },
-  { title: "Console", url: "/admin/console", icon: Terminal },
-  { title: "Audit Log", url: "/admin/audit", icon: ClipboardList },
-  { title: "System Monitor", url: "/admin/system", icon: Shield },
-  { title: "Support Inbox", url: "/admin/tickets", icon: LifeBuoy },
-  { title: "Customer Surveys", url: "/admin/surveys", icon: MessageSquare },
-  { title: "Settings", url: "/admin/settings", icon: Settings },
-  { title: "My Profile", url: "/admin/profile", icon: UserCircle },
+interface AdminNavItem {
+  title: string;
+  url: string;
+  icon: typeof LayoutDashboard;
+}
+
+interface AdminNavGroup {
+  label: string;
+  items: AdminNavItem[];
+}
+
+const adminNavGroups: AdminNavGroup[] = [
+  {
+    label: "Overview",
+    items: [
+      { title: "Command Center", url: "/admin", icon: LayoutDashboard },
+    ],
+  },
+  {
+    label: "User Management",
+    items: [
+      { title: "Users", url: "/admin/users", icon: Users },
+      { title: "Support Inbox", url: "/admin/tickets", icon: LifeBuoy },
+      { title: "Customer Surveys", url: "/admin/surveys", icon: MessageSquare },
+    ],
+  },
+  {
+    label: "AI & Automation",
+    items: [
+      { title: "The Crew Status", url: "/admin/agents", icon: Bot },
+      { title: "Agent Runs", url: "/admin/agent-runs", icon: Bot },
+      { title: "Queue", url: "/admin/queue", icon: Layers },
+    ],
+  },
+  {
+    label: "System & Monitoring",
+    items: [
+      { title: "System Monitor", url: "/admin/system", icon: Shield },
+      { title: "Console", url: "/admin/console", icon: Terminal },
+      { title: "Event Log", url: "/admin/logs", icon: ScrollText },
+      { title: "Audit Log", url: "/admin/audit", icon: ClipboardList },
+    ],
+  },
+  {
+    label: "Account",
+    items: [
+      { title: "Settings", url: "/admin/settings", icon: Settings },
+      { title: "My Profile", url: "/admin/profile", icon: UserCircle },
+    ],
+  },
 ];
 
 function AdminSidebar() {
@@ -34,6 +70,7 @@ function AdminSidebar() {
   const collapsed = state === "collapsed";
   const location = useLocation();
   const navigate = useNavigate();
+
   const isActive = (path: string) =>
     path === "/admin" ? location.pathname === path : location.pathname.startsWith(path);
 
@@ -49,28 +86,30 @@ function AdminSidebar() {
           )}
         </div>
 
-        <SidebarGroup>
-          <SidebarGroupLabel>Command Center</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {adminNav.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild isActive={isActive(item.url)}>
-                    <NavLink
-                      to={item.url}
-                      end={item.url === "/admin"}
-                      className="hover:bg-sidebar-accent/50"
-                      activeClassName="bg-sidebar-accent text-sidebar-primary font-medium"
-                    >
-                      <item.icon className="mr-2 h-4 w-4" />
-                      {!collapsed && <span>{item.title}</span>}
-                    </NavLink>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+        {adminNavGroups.map((group) => (
+          <SidebarGroup key={group.label}>
+            <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {group.items.map((item) => (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton asChild isActive={isActive(item.url)}>
+                      <NavLink
+                        to={item.url}
+                        end={item.url === "/admin"}
+                        className="hover:bg-sidebar-accent/50"
+                        activeClassName="bg-sidebar-accent text-sidebar-primary font-medium"
+                      >
+                        <item.icon className="mr-2 h-4 w-4" />
+                        {!collapsed && <span>{item.title}</span>}
+                      </NavLink>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ))}
 
         <SidebarGroup>
           <SidebarGroupContent>

--- a/src/shell/navigation.ts
+++ b/src/shell/navigation.ts
@@ -5,9 +5,22 @@
  */
 
 import {
-  LayoutDashboard, Search, ClipboardList, UserCircle, Target,
-  DollarSign, Compass, Mic, Zap, HelpCircle, Settings,
-  Users, Database, FileText, Calendar, Briefcase,
+  LayoutDashboard,
+  Search,
+  ClipboardList,
+  UserCircle,
+  Target,
+  DollarSign,
+  Compass,
+  Mic,
+  Zap,
+  HelpCircle,
+  Settings,
+  Users,
+  Database,
+  FileText,
+  Calendar,
+  Briefcase,
 } from "lucide-react";
 
 export interface NavItem {
@@ -17,27 +30,43 @@ export interface NavItem {
 }
 
 export const jobSeekerNav: NavItem[] = [
+  // ── Overview ──
   { title: "Mission Control", url: "/dashboard", icon: LayoutDashboard },
-  { title: "Match Score Lab", url: "/job-seeker", icon: Target },
-  { title: "Opportunity Radar", url: "/job-search", icon: Search },
-  { title: "Pipeline", url: "/applications", icon: ClipboardList },
-  { title: "Offer Desk", url: "/offers", icon: DollarSign },
-  { title: "Flight Plan", url: "/career", icon: Compass },
-  { title: "Interview Simulator", url: "/interview-prep", icon: Mic },
-  { title: "Autopilot Mode", url: "/auto-apply", icon: Zap },
-  { title: "Open Market", url: "/gigs", icon: Briefcase },
-  { title: "Skill Store", url: "/services", icon: Briefcase },
+
+  // ── Profile & Preparation ──
   { title: "Career Profile", url: "/profile", icon: UserCircle },
+  { title: "Match Score Lab", url: "/job-seeker", icon: Target },
+
+  // ── Job Search & Applications ──
+  { title: "Opportunity Radar", url: "/job-search", icon: Search },
+  { title: "Autopilot Mode", url: "/auto-apply", icon: Zap },
+  { title: "Pipeline", url: "/applications", icon: ClipboardList },
+
+  // ── Interview & Offers ──
+  { title: "Interview Simulator", url: "/interview-prep", icon: Mic },
+  { title: "Offer Desk", url: "/offers", icon: DollarSign },
+
+  // ── Career Growth ──
+  { title: "Flight Plan", url: "/career", icon: Compass },
+  { title: "Open Market", url: "/gigs", icon: Briefcase },
+  { title: "Skill Store", url: "/services", icon: FileText },
+
+  // ── Account ──
   { title: "Settings", url: "/settings", icon: Settings },
   { title: "Support Inbox", url: "/support", icon: HelpCircle },
 ];
 
 export const hiringManagerNav: NavItem[] = [
+  // ── Overview ──
   { title: "Mission Control", url: "/hiring-manager", icon: LayoutDashboard },
-  { title: "Candidates", url: "/candidates", icon: Database },
-  { title: "Talent Search", url: "/talent-search", icon: Search },
+
+  // ── Recruitment Pipeline ──
   { title: "Job Postings", url: "/job-postings", icon: FileText },
+  { title: "Talent Search", url: "/talent-search", icon: Search },
+  { title: "Candidates", url: "/candidates", icon: Database },
   { title: "Interviews", url: "/interview-scheduling", icon: Calendar },
+
+  // ── Account ──
   { title: "Settings", url: "/settings", icon: Settings },
 ];
 


### PR DESCRIPTION
## Summary
- Reorganized Job Seeker sidebar to follow natural user journey: Dashboard → Profile → Job Search → Applications → Interviews → Offers → Career Growth → Account
- - Reorganized Hiring Manager sidebar to follow hiring workflow: Dashboard → Job Postings → Talent Search → Candidates → Interviews → Settings
- - Reorganized Admin sidebar into logical groups: Overview, User Management, AI & Automation, System & Monitoring, Account
- - Fixed Skill Store icon (was duplicate Briefcase, now FileText)