### PR TITLE
fix: skip env var validation in CI builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,11 +3,11 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
 export default defineConfig(({ mode }) => {
-  // Validate required environment variables
+  // Validate required environment variables (skip in CI — no secrets needed for compilation)
   const supabaseUrl = process.env.VITE_SUPABASE_URL;
   const supabaseKey = process.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
-  if (mode === "production") {
+  if (mode === "production" && !process.env.CI) {
     if (!supabaseUrl) throw new Error("VITE_SUPABASE_URL is required");
     if (!supabaseKey) throw new Error("VITE_SUPABASE_PUBLISHABLE_KEY is required");
   }


### PR DESCRIPTION
The CI build step was failing because vite build runs in production mode by default, which triggers env var validation for VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY. These secrets aren't available in CI (nor should they be). Added a process.env.CI check to skip validation in CI environments, since CI only needs to verify compilation succeeds.