### PR TITLE
feat: add light/dark/auto theme system with user preference

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,25 +1,25 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
   <defs>
-      <style>
-            :root { --brand-fill: #3B5BDB; }
-                  @media (prefers-color-scheme: dark) { :root { --brand-fill: #748FFC; } }
-                      </style>
-                        </defs>
+    <style>
+      :root { --brand-fill: #3B5BDB; }
+      @media (prefers-color-scheme: dark) { :root { --brand-fill: #748FFC; } }
+    </style>
+  </defs>
 
-                          <!-- Dashed outer ring -->
-                            <circle cx="32" cy="32" r="29" fill="none" stroke="var(--brand-fill, #3B5BDB)"
-                                stroke-width="1.5" stroke-dasharray="6 4" opacity="0.5" />
+  <!-- Dashed outer ring -->
+  <circle cx="32" cy="32" r="29" fill="none" stroke="var(--brand-fill, #3B5BDB)"
+    stroke-width="1.5" stroke-dasharray="6 4" opacity="0.5" />
 
-                                  <!-- Solid mid ring -->
-                                    <circle cx="32" cy="32" r="21" fill="none" stroke="var(--brand-fill, #3B5BDB)"
-                                        stroke-width="2" opacity="0.7" />
+  <!-- Solid mid ring -->
+  <circle cx="32" cy="32" r="21" fill="none" stroke="var(--brand-fill, #3B5BDB)"
+    stroke-width="2" opacity="0.7" />
 
-                                          <!-- Core filled circle -->
-                                            <circle cx="32" cy="32" r="10" fill="var(--brand-fill, #3B5BDB)" />
+  <!-- Core filled circle -->
+  <circle cx="32" cy="32" r="10" fill="var(--brand-fill, #3B5BDB)" />
 
-                                              <!-- Orbit nodes at cardinal points -->
-                                                <circle cx="32" cy="3"  r="3" fill="var(--brand-fill, #3B5BDB)" />  <!-- top -->
-                                                  <circle cx="61" cy="32" r="3" fill="var(--brand-fill, #3B5BDB)" />  <!-- right -->
-                                                    <circle cx="32" cy="61" r="3" fill="var(--brand-fill, #3B5BDB)" />  <!-- bottom -->
-                                                      <circle cx="3"  cy="32" r="3" fill="var(--brand-fill, #3B5BDB)" />  <!-- left -->
-                                                      </svg>
+  <!-- Orbit nodes at cardinal points -->
+  <circle cx="32" cy="3"  r="3" fill="var(--brand-fill, #3B5BDB)" />  <!-- top -->
+  <circle cx="61" cy="32" r="3" fill="var(--brand-fill, #3B5BDB)" />  <!-- right -->
+  <circle cx="32" cy="61" r="3" fill="var(--brand-fill, #3B5BDB)" />  <!-- bottom -->
+  <circle cx="3"  cy="32" r="3" fill="var(--brand-fill, #3B5BDB)" />  <!-- left -->
+</svg>

--- a/src/components/OrbitalLogo.tsx
+++ b/src/components/OrbitalLogo.tsx
@@ -1,50 +1,50 @@
 /**
- * OrbitalLogo — The iCareerOS orbital icon.
-   * A filled circle core with a solid mid-ring, dashed outer ring,
+ * OrbitalLogo â The iCareerOS orbital icon.
+ * A filled circle core with a solid mid-ring, dashed outer ring,
  * and 4 orbit nodes at cardinal points.
  * Automatically adapts to the current theme via CSS variables.
-   */
+ */
 
 interface OrbitalLogoProps {
-    size?: number;
+  size?: number;
   className?: string;
 }
 
 export default function OrbitalLogo({ size = 32, className = "" }: OrbitalLogoProps) {
   return (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 64 64"
-          width={size}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 64 64"
+      width={size}
       height={size}
       className={className}
-          aria-label="iCareerOS logo"
-          role="img"
-        >
-    {/* Dashed outer ring */}
+      aria-label="iCareerOS logo"
+      role="img"
+    >
+      {/* Dashed outer ring */}
       <circle
-            cx="32" cy="32" r="29"
-            fill="none"
-            stroke="var(--brand, #3B5BDB)"
-            strokeWidth="1.5"
-            strokeDasharray="6 4"
-            opacity="0.5"
-          />
-    {/* Solid mid ring */}
+        cx="32" cy="32" r="29"
+        fill="none"
+        stroke="var(--brand, #3B5BDB)"
+        strokeWidth="1.5"
+        strokeDasharray="6 4"
+        opacity="0.5"
+      />
+      {/* Solid mid ring */}
       <circle
-            cx="32" cy="32" r="21"
-            fill="none"
-            stroke="var(--brand, #3B5BDB)"
-            strokeWidth="2"
-            opacity="0.7"
-          />
-    {/* Core filled circle */}
+        cx="32" cy="32" r="21"
+        fill="none"
+        stroke="var(--brand, #3B5BDB)"
+        strokeWidth="2"
+        opacity="0.7"
+      />
+      {/* Core filled circle */}
       <circle cx="32" cy="32" r="10" fill="var(--brand, #3B5BDB)" />
-    {/* Orbit nodes at cardinal points */}
+      {/* Orbit nodes at cardinal points */}
       <circle cx="32" cy="3"  r="3" fill="var(--brand, #3B5BDB)" />
-          <circle cx="61" cy="32" r="3" fill="var(--brand, #3B5BDB)" />
-          <circle cx="32" cy="61" r="3" fill="var(--brand, #3B5BDB)" />
-          <circle cx="3"  cy="32" r="3" fill="var(--brand, #3B5BDB)" />
-        </svg>
-      );
+      <circle cx="61" cy="32" r="3" fill="var(--brand, #3B5BDB)" />
+      <circle cx="32" cy="61" r="3" fill="var(--brand, #3B5BDB)" />
+      <circle cx="3"  cy="32" r="3" fill="var(--brand, #3B5BDB)" />
+    </svg>
+  );
 }

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,8 +1,8 @@
 /**
- * ThemeSelector — Appearance settings section.
-   * Three clickable cards (Light, Dark, Automatic) with mini-UI previews.
-   * Clicking a card calls setTheme() immediately (auto-saves to Supabase).
-   */
+ * ThemeSelector â Appearance settings section.
+ * Three clickable cards (Light, Dark, Automatic) with mini-UI previews.
+ * Clicking a card calls setTheme() immediately (auto-saves to Supabase).
+ */
 
 import { useTheme, type ThemePreference } from "@/contexts/ThemeContext";
 import { Monitor, Sun, Moon } from "lucide-react";
@@ -13,85 +13,85 @@ const OPTIONS: { value: ThemePreference; label: string; icon: typeof Sun }[] = [
   { value: "system", label: "Automatic", icon: Monitor },
 ];
 
-/* ── Mini-UI preview thumbnails ──────────────────────────────────────────── */
+/* ââ Mini-UI preview thumbnails ââââââââââââââââââââââââââââââââââââââââââââ */
 
 function LightPreview() {
-    return (
-          <div className="w-full h-20 rounded-md overflow-hidden border border-[#E2E4EC] bg-[#F5F6FA] p-2 flex flex-col gap-1.5">
-            <div className="flex items-center gap-1.5">
-              <div className="w-3 h-3 rounded-full bg-[#3B5BDB]" />
-              <div className="h-1.5 w-12 rounded bg-[#E2E4EC]" />
-            </div>
-            <div className="flex-1 rounded bg-white border border-[#E2E4EC] p-1.5 flex flex-col gap-1">
-              <div className="h-1.5 w-16 rounded bg-[#1C1F36] opacity-60" />
-              <div className="h-1.5 w-12 rounded bg-[#9CA3AF] opacity-40" />
-              <div className="h-1.5 w-8 rounded bg-[#3B5BDB] opacity-50" />
-            </div>
-          </div>
-        );
+  return (
+    <div className="w-full h-20 rounded-md overflow-hidden border border-[#E2E4EC] bg-[#F5F6FA] p-2 flex flex-col gap-1.5">
+      <div className="flex items-center gap-1.5">
+        <div className="w-3 h-3 rounded-full bg-[#3B5BDB]" />
+        <div className="h-1.5 w-12 rounded bg-[#E2E4EC]" />
+      </div>
+      <div className="flex-1 rounded bg-white border border-[#E2E4EC] p-1.5 flex flex-col gap-1">
+        <div className="h-1.5 w-16 rounded bg-[#1C1F36] opacity-60" />
+        <div className="h-1.5 w-12 rounded bg-[#9CA3AF] opacity-40" />
+        <div className="h-1.5 w-8 rounded bg-[#3B5BDB] opacity-50" />
+      </div>
+    </div>
+  );
 }
 
 function DarkPreview() {
-    return (
-          <div className="w-full h-20 rounded-md overflow-hidden border border-[#2A2F3E] bg-[#0F1117] p-2 flex flex-col gap-1.5">
-            <div className="flex items-center gap-1.5">
-              <div className="w-3 h-3 rounded-full bg-[#748FFC]" />
-              <div className="h-1.5 w-12 rounded bg-[#2A2F3E]" />
-            </div>
-            <div className="flex-1 rounded bg-[#161B27] border border-[#2A2F3E] p-1.5 flex flex-col gap-1">
-              <div className="h-1.5 w-16 rounded bg-[#E8EAF6] opacity-60" />
-              <div className="h-1.5 w-12 rounded bg-[#4B5563] opacity-40" />
-              <div className="h-1.5 w-8 rounded bg-[#748FFC] opacity-50" />
-            </div>
-          </div>
-        );
+  return (
+    <div className="w-full h-20 rounded-md overflow-hidden border border-[#2A2F3E] bg-[#0F1117] p-2 flex flex-col gap-1.5">
+      <div className="flex items-center gap-1.5">
+        <div className="w-3 h-3 rounded-full bg-[#748FFC]" />
+        <div className="h-1.5 w-12 rounded bg-[#2A2F3E]" />
+      </div>
+      <div className="flex-1 rounded bg-[#161B27] border border-[#2A2F3E] p-1.5 flex flex-col gap-1">
+        <div className="h-1.5 w-16 rounded bg-[#E8EAF6] opacity-60" />
+        <div className="h-1.5 w-12 rounded bg-[#4B5563] opacity-40" />
+        <div className="h-1.5 w-8 rounded bg-[#748FFC] opacity-50" />
+      </div>
+    </div>
+  );
 }
 
 function AutoPreview() {
-    return (
-          <div className="w-full h-20 rounded-md overflow-hidden flex">
+  return (
+    <div className="w-full h-20 rounded-md overflow-hidden flex">
       {/* Left half: light */}
       <div className="w-1/2 bg-[#F5F6FA] border border-[#E2E4EC] border-r-0 rounded-l-md p-1.5 flex flex-col gap-1">
-              <div className="w-2.5 h-2.5 rounded-full bg-[#3B5BDB]" />
-              <div className="flex-1 rounded-sm bg-white p-1 flex flex-col gap-0.5">
-                <div className="h-1 w-8 rounded bg-[#1C1F36] opacity-50" />
-                <div className="h-1 w-6 rounded bg-[#9CA3AF] opacity-30" />
-              </div>
-            </div>
+        <div className="w-2.5 h-2.5 rounded-full bg-[#3B5BDB]" />
+        <div className="flex-1 rounded-sm bg-white p-1 flex flex-col gap-0.5">
+          <div className="h-1 w-8 rounded bg-[#1C1F36] opacity-50" />
+          <div className="h-1 w-6 rounded bg-[#9CA3AF] opacity-30" />
+        </div>
+      </div>
       {/* Right half: dark */}
-            <div className="w-1/2 bg-[#0F1117] border border-[#2A2F3E] border-l-0 rounded-r-md p-1.5 flex flex-col gap-1">
+      <div className="w-1/2 bg-[#0F1117] border border-[#2A2F3E] border-l-0 rounded-r-md p-1.5 flex flex-col gap-1">
         <div className="w-2.5 h-2.5 rounded-full bg-[#748FFC]" />
-                      <div className="flex-1 rounded-sm bg-[#161B27] p-1 flex flex-col gap-0.5">
-                        <div className="h-1 w-8 rounded bg-[#E8EAF6] opacity-50" />
-                        <div className="h-1 w-6 rounded bg-[#4B5563] opacity-30" />
-                      </div>
-                    </div>
-                  </div>
-                );
-       }
+        <div className="flex-1 rounded-sm bg-[#161B27] p-1 flex flex-col gap-0.5">
+          <div className="h-1 w-8 rounded bg-[#E8EAF6] opacity-50" />
+          <div className="h-1 w-6 rounded bg-[#4B5563] opacity-30" />
+        </div>
+      </div>
+    </div>
+  );
+}
 
 const previews: Record<ThemePreference, () => JSX.Element> = {
   light: LightPreview,
-      dark: DarkPreview,
-      system: AutoPreview,
-    };
+  dark: DarkPreview,
+  system: AutoPreview,
+};
 
-/* ── Main component ──────────────────────────────────────────────────────── */
+/* ââ Main component ââââââââââââââââââââââââââââââââââââââââââââââââââââââââ */
 
 export default function ThemeSelector() {
-    const { theme, setTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
 
   return (
-        <div className="space-y-3">
-          <div>
-            <h3 className="text-sm font-medium text-foreground">Appearance</h3>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              Choose how iCareerOS looks. Select Automatic to match your system settings.
+    <div className="space-y-3">
+      <div>
+        <h3 className="text-sm font-medium text-foreground">Appearance</h3>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Choose how iCareerOS looks. Select Automatic to match your system settings.
         </p>
       </div>
 
       <div className="grid grid-cols-3 gap-3">
-{OPTIONS.map(({ value, label, icon: Icon }) => {
+        {OPTIONS.map(({ value, label, icon: Icon }) => {
           const isSelected = theme === value;
           const Preview = previews[value];
 
@@ -99,42 +99,42 @@ export default function ThemeSelector() {
             <button
               key={value}
               type="button"
-                              onClick={() => setTheme(value)}
+              onClick={() => setTheme(value)}
               className={`
-                                relative flex flex-col items-center gap-2 rounded-xl p-3
-                                border-2 transition-all duration-150 cursor-pointer
-                                hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
-                                ${isSelected
-                                  ? "border-[var(--brand,#3B5BDB)] bg-[var(--bg-surface,#FFFFFF)] shadow-sm"
-                                  : "border-border bg-card hover:border-muted-foreground/30"
+                relative flex flex-col items-center gap-2 rounded-xl p-3
+                border-2 transition-all duration-150 cursor-pointer
+                hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+                ${isSelected
+                  ? "border-[var(--brand,#3B5BDB)] bg-[var(--bg-surface,#FFFFFF)] shadow-sm"
+                  : "border-border bg-card hover:border-muted-foreground/30"
                 }
-                              `}
+              `}
               aria-pressed={isSelected}
-                              aria-label={`${label} theme`}
-                            >
-                {/* Selected indicator dot */}
-                              <div
-                                className={`
-                                  w-2.5 h-2.5 rounded-full transition-colors duration-150
-                                  ${isSelected
+              aria-label={`${label} theme`}
+            >
+              {/* Selected indicator dot */}
+              <div
+                className={`
+                  w-2.5 h-2.5 rounded-full transition-colors duration-150
+                  ${isSelected
                     ? "bg-[var(--brand,#3B5BDB)]"
-                                    : "bg-border"
-                }
+                    : "bg-border"
+                  }
                 `}
               />
 
-                {/* Preview thumbnail */}
-                              <Preview />
+              {/* Preview thumbnail */}
+              <Preview />
 
-                {/* Label */}
+              {/* Label */}
               <div className="flex items-center gap-1.5">
                 <Icon className="w-3.5 h-3.5 text-muted-foreground" />
-                                <span className="text-xs font-medium text-foreground">{label}</span>
-                              </div>
-                            </button>
-                          );
-})}
-      </div>
-            </div>
+                <span className="text-xs font-medium text-foreground">{label}</span>
+              </div>
+            </button>
           );
+        })}
+      </div>
+    </div>
+  );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -6,18 +6,17 @@
 
 /* =========================================
    iCareerOS Design System
-   Deep Navy × Teal — Confident & Precise
+   Theme-aware â Light / Dark / Auto
    ========================================= */
 
 @layer base {
-  :root {
+  :root,
+  [data-theme="light"] {
     /* Core surfaces */
     --background: 220 30% 97%;
     --foreground: 220 40% 10%;
-
     --card: 0 0% 100%;
     --card-foreground: 220 40% 10%;
-
     --popover: 0 0% 100%;
     --popover-foreground: 220 40% 10%;
 
@@ -73,28 +72,76 @@
     --sidebar-accent-foreground: 220 10% 90%;
     --sidebar-border: 220 40% 20%;
     --sidebar-ring: 172 70% 42%;
+
+    /* Theme-specific semantic tokens */
+    --bg-page: #F5F6FA;
+    --bg-surface: #FFFFFF;
+    --bg-surface-2: #EEF0FD;
+    --border-theme: #E2E4EC;
+    --brand: #3B5BDB;
+    --brand-text: #FFFFFF;
+    --text-primary: #1C1F36;
+    --text-secondary: #6B7280;
+    --text-muted: #9CA3AF;
   }
 
-  .dark {
+  [data-theme="dark"] {
     --background: 220 40% 8%;
     --foreground: 220 10% 95%;
     --card: 220 35% 12%;
     --card-foreground: 220 10% 95%;
     --popover: 220 35% 12%;
     --popover-foreground: 220 10% 95%;
+
     --primary: 172 70% 48%;
     --primary-foreground: 220 65% 10%;
+
     --secondary: 220 25% 18%;
     --secondary-foreground: 220 10% 88%;
+
     --muted: 220 25% 18%;
     --muted-foreground: 220 15% 60%;
+
     --accent: 172 70% 48%;
     --accent-foreground: 220 65% 10%;
+
     --destructive: 4 72% 55%;
     --destructive-foreground: 0 0% 100%;
+
     --border: 220 25% 18%;
     --input: 220 25% 18%;
     --ring: 172 70% 48%;
+
+    /* Dark gradients */
+    --gradient-hero: linear-gradient(135deg, hsl(220 40% 6%), hsl(220 40% 12%) 50%, hsl(200 35% 10%));
+    --gradient-card: linear-gradient(145deg, hsl(220 35% 12%), hsl(220 30% 10%));
+    --gradient-teal: linear-gradient(135deg, hsl(172 70% 48%), hsl(185 65% 42%));
+
+    --shadow-card: 0 4px 24px -4px hsl(0 0% 0% / 0.3), 0 1px 4px hsl(0 0% 0% / 0.2);
+    --shadow-elevated: 0 12px 40px -8px hsl(0 0% 0% / 0.4), 0 4px 12px hsl(0 0% 0% / 0.25);
+    --shadow-teal: 0 8px 24px -4px hsl(172 70% 48% / 0.25);
+    --shadow-primary: 0 8px 24px -4px hsl(172 70% 48% / 0.2);
+
+    /* Sidebar (dark variant) */
+    --sidebar-background: 220 40% 6%;
+    --sidebar-foreground: 220 10% 88%;
+    --sidebar-primary: 172 70% 48%;
+    --sidebar-primary-foreground: 220 65% 10%;
+    --sidebar-accent: 220 30% 15%;
+    --sidebar-accent-foreground: 220 10% 90%;
+    --sidebar-border: 220 30% 14%;
+    --sidebar-ring: 172 70% 48%;
+
+    /* Theme-specific semantic tokens */
+    --bg-page: #0F1117;
+    --bg-surface: #161B27;
+    --bg-surface-2: #1E2340;
+    --border-theme: #2A2F3E;
+    --brand: #748FFC;
+    --brand-text: #0F1117;
+    --text-primary: #E8EAF6;
+    --text-secondary: #9CA3AF;
+    --text-muted: #4B5563;
   }
 }
 
@@ -102,295 +149,13 @@
   * {
     @apply border-border;
   }
-
   body {
     @apply bg-background text-foreground;
     font-family: 'Inter', system-ui, sans-serif;
     -webkit-font-smoothing: antialiased;
   }
-
   h1, h2, h3 {
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Syne:wght@700;800&display=swap');
-     
-     @tailwind base;
-     @tailwind components;
-     @tailwind utilities;
-     
-     /* =========================================
-        iCareerOS Design System
-        Theme-aware — Light / Dark / Auto
-        ========================================= */
-     
-     @layer base {
-          :root,
-          [data-theme="light"] {
-                 /* Core surfaces */
-                 --background: 220 30% 97%;
-                 --foreground: 220 40% 10%;
-                 --card: 0 0% 100%;
-                 --card-foreground: 220 40% 10%;
-                 --popover: 0 0% 100%;
-                 --popover-foreground: 220 40% 10%;
-             
-                 /* Brand: Deep Navy */
-                 --primary: 220 65% 18%;
-                 --primary-foreground: 0 0% 98%;
-             
-                 /* Secondary: Slate */
-                 --secondary: 220 20% 92%;
-                 --secondary-foreground: 220 40% 18%;
-             
-                 /* Muted */
-                 --muted: 220 15% 94%;
-                 --muted-foreground: 220 15% 50%;
-             
-                 /* Accent: Teal */
-                 --accent: 172 70% 42%;
-                 --accent-foreground: 0 0% 100%;
-             
-                 /* Status */
-                 --destructive: 4 86% 58%;
-                 --destructive-foreground: 0 0% 100%;
-                 --success: 145 65% 42%;
-                 --success-foreground: 0 0% 100%;
-                 --warning: 38 92% 50%;
-                 --warning-foreground: 0 0% 10%;
-             
-                 /* Chrome */
-                 --border: 220 20% 88%;
-                 --input: 220 20% 88%;
-                 --ring: 172 70% 42%;
-                 --radius: 0.75rem;
-             
-                 /* Custom gradients & glows */
-                 --gradient-hero: linear-gradient(135deg, hsl(220 65% 12%), hsl(220 65% 22%) 50%, hsl(200 60% 18%));
-                 --gradient-card: linear-gradient(145deg, hsl(0 0% 100%), hsl(220 15% 97%));
-                 --gradient-teal: linear-gradient(135deg, hsl(172 70% 42%), hsl(185 75% 38%));
-                 --gradient-score-high: linear-gradient(90deg, hsl(145 65% 42%), hsl(172 70% 48%));
-                 --gradient-score-mid: linear-gradient(90deg, hsl(38 92% 50%), hsl(30 90% 55%));
-                 --gradient-score-low: linear-gradient(90deg, hsl(4 86% 55%), hsl(10 80% 58%));
-             
-                 --shadow-card: 0 4px 24px -4px hsl(220 40% 15% / 0.08), 0 1px 4px hsl(220 40% 15% / 0.04);
-                 --shadow-elevated: 0 12px 40px -8px hsl(220 40% 15% / 0.14), 0 4px 12px hsl(220 40% 15% / 0.06);
-                 --shadow-teal: 0 8px 24px -4px hsl(172 70% 42% / 0.3);
-                 --shadow-primary: 0 8px 24px -4px hsl(220 65% 18% / 0.3);
-             
-                 /* Sidebar */
-                 --sidebar-background: 220 65% 14%;
-                 --sidebar-foreground: 220 10% 88%;
-                 --sidebar-primary: 172 70% 42%;
-                 --sidebar-primary-foreground: 0 0% 100%;
-                 --sidebar-accent: 220 40% 22%;
-                 --sidebar-accent-foreground: 220 10% 90%;
-                 --sidebar-border: 220 40% 20%;
-                 --sidebar-ring: 172 70% 42%;
-             
-                 /* Theme-specific semantic tokens */
-                 --bg-page: #F5F6FA;
-                 --bg-surface: #FFFFFF;
-                 --bg-surface-2: #EEF0FD;
-                 --border-theme: #E2E4EC;
-                 --brand: #3B5BDB;
-                 --brand-text: #FFFFFF;
-                 --text-primary: #1C1F36;
-                 --text-secondary: #6B7280;
-                 --text-muted: #9CA3AF;
-          }
-        
-          [data-theme="dark"] {
-                 --background: 220 40% 8%;
-                 --foreground: 220 10% 95%;
-                 --card: 220 35% 12%;
-                 --card-foreground: 220 10% 95%;
-                 --popover: 220 35% 12%;
-                 --popover-foreground: 220 10% 95%;
-             
-                 --primary: 172 70% 48%;
-                 --primary-foreground: 220 65% 10%;
-             
-                 --secondary: 220 25% 18%;
-                 --secondary-foreground: 220 10% 88%;
-             
-                 --muted: 220 25% 18%;
-                 --muted-foreground: 220 15% 60%;
-             
-                 --accent: 172 70% 48%;
-                 --accent-foreground: 220 65% 10%;
-             
-                 --destructive: 4 72% 55%;
-                 --destructive-foreground: 0 0% 100%;
-             
-                 --border: 220 25% 18%;
-                 --input: 220 25% 18%;
-                 --ring: 172 70% 48%;
-             
-                 /* Dark gradients */
-                 --gradient-hero: linear-gradient(135deg, hsl(220 40% 6%), hsl(220 40% 12%) 50%, hsl(200 35% 10%));
-                 --gradient-card: linear-gradient(145deg, hsl(220 35% 12%), hsl(220 30% 10%));
-                 --gradient-teal: linear-gradient(135deg, hsl(172 70% 48%), hsl(185 65% 42%));
-             
-                 --shadow-card: 0 4px 24px -4px hsl(0 0% 0% / 0.3), 0 1px 4px hsl(0 0% 0% / 0.2);
-                 --shadow-elevated: 0 12px 40px -8px hsl(0 0% 0% / 0.4), 0 4px 12px hsl(0 0% 0% / 0.25);
-                 --shadow-teal: 0 8px 24px -4px hsl(172 70% 48% / 0.25);
-                 --shadow-primary: 0 8px 24px -4px hsl(172 70% 48% / 0.2);
-             
-                 /* Sidebar (dark variant) */
-                 --sidebar-background: 220 40% 6%;
-                 --sidebar-foreground: 220 10% 88%;
-                 --sidebar-primary: 172 70% 48%;
-                 --sidebar-primary-foreground: 220 65% 10%;
-                 --sidebar-accent: 220 30% 15%;
-                 --sidebar-accent-foreground: 220 10% 90%;
-                 --sidebar-border: 220 30% 14%;
-                 --sidebar-ring: 172 70% 48%;
-             
-                 /* Theme-specific semantic tokens */
-                 --bg-page: #0F1117;
-                 --bg-surface: #161B27;
-                 --bg-surface-2: #1E2340;
-                 --border-theme: #2A2F3E;
-                 --brand: #748FFC;
-                 --brand-text: #0F1117;
-                 --text-primary: #E8EAF6;
-                 --text-secondary: #9CA3AF;
-                 --text-muted: #4B5563;
-          }
-     }
-     
-     @layer base {
-          * {
-                 @apply border-border;
-          }
-          body {
-                 @apply bg-background text-foreground;
-                 font-family: 'Inter', system-ui, sans-serif;
-                 -webkit-font-smoothing: antialiased;
-          }
-          h1, h2, h3 {
-                 font-family: 'Syne', 'Inter', sans-serif;
-          }
-     }
-     
-     @layer utilities {
-          .font-display {
-                 font-family: 'Syne', sans-serif;
-          }
-          .gradient-hero {
-                 background: var(--gradient-hero);
-          }
-          .gradient-teal {
-                 background: var(--gradient-teal);
-          }
-          .gradient-card {
-                 background: var(--gradient-card);
-          }
-          .shadow-card {
-                 box-shadow: var(--shadow-card);
-          }
-          .shadow-elevated {
-                 box-shadow: var(--shadow-elevated);
-          }
-          .shadow-teal {
-                 box-shadow: var(--shadow-teal);
-          }
-          .shadow-primary-glow {
-                 box-shadow: var(--shadow-primary);
-          }
-          .text-gradient-teal {
-                 background: var(--gradient-teal);
-                 -webkit-background-clip: text;
-                 -webkit-text-fill-color: transparent;
-                 background-clip: text;
-          }
-          .score-bar-high {
-                 background: var(--gradient-score-high);
-          }
-          .score-bar-mid {
-                 background: var(--gradient-score-mid);
-          }
-          .score-bar-low {
-                 background: var(--gradient-score-low);
-          }
-          .glass {
-                 background: hsl(0 0% 100% / 0.08);
-                 backdrop-filter: blur(12px);
-                 border: 1px solid hsl(0 0% 100% / 0.12);
-          }
-        
-          /* Theme semantic utilities */
-          .bg-page {
-                 background-color: var(--bg-page);
-          }
-          .bg-surface {
-                 background-color: var(--bg-surface);
-          }
-          .bg-surface-2 {
-                 background-color: var(--bg-surface-2);
-          }
-          .border-theme {
-                 border-color: var(--border-theme);
-          }
-          .bg-brand {
-                 background-color: var(--brand);
-          }
-          .text-brand {
-                 color: var(--brand);
-          }
-          .text-on-brand {
-                 color: var(--brand-text);
-          }
-          .text-theme-primary {
-                 color: var(--text-primary);
-          }
-          .text-theme-secondary {
-                 color: var(--text-secondary);
-          }
-          .text-theme-muted {
-                 color: var(--text-muted);
-          }
-        
-          /* Animations */
-          .animate-fade-up {
-                 animation: fade-up 0.5s ease-out both;
-          }
-          .animate-fade-in {
-                 animation: fade-in 0.4s ease-out both;
-          }
-          .animate-scale-in {
-                 animation: scale-in 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
-          }
-          .animate-count-up {
-                 animation: count-up 1.2s ease-out both;
-          }
-     }
-     
-     @keyframes fade-up {
-          from { opacity: 0; transform: translateY(20px); }
-          to   { opacity: 1; transform: translateY(0); }
-     }
-     @keyframes fade-in {
-          from { opacity: 0; }
-          to   { opacity: 1; }
-     }
-     @keyframes scale-in {
-          from { opacity: 0; transform: scale(0.88); }
-          to   { opacity: 1; transform: scale(1); }
-     }
-     @keyframes count-up {
-          from { opacity: 0; }
-          to   { opacity: 1; }
-     }
-     @keyframes bar-grow {
-          from { width: 0%; }
-          to   { width: var(--bar-width); }
-     }
-     @keyframes pulse-glow {
-          0%, 100% { box-shadow: 0 0 0 0 hsl(172 70% 42% / 0.4); }
-          50%      { box-shadow: 0 0 0 8px hsl(172 70% 42% / 0); }
-     }
-     .animate-pulse-glow {
-          animation: pulse-glow 2s ease-in-out infinite;
-     }font-family: 'Syne', 'Inter', sans-serif;
+    font-family: 'Syne', 'Inter', sans-serif;
   }
 }
 
@@ -398,72 +163,90 @@
   .font-display {
     font-family: 'Syne', sans-serif;
   }
-
   .gradient-hero {
     background: var(--gradient-hero);
   }
-
   .gradient-teal {
     background: var(--gradient-teal);
   }
-
   .gradient-card {
     background: var(--gradient-card);
   }
-
   .shadow-card {
     box-shadow: var(--shadow-card);
   }
-
   .shadow-elevated {
     box-shadow: var(--shadow-elevated);
   }
-
   .shadow-teal {
     box-shadow: var(--shadow-teal);
   }
-
   .shadow-primary-glow {
     box-shadow: var(--shadow-primary);
   }
-
   .text-gradient-teal {
     background: var(--gradient-teal);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
   }
-
   .score-bar-high {
     background: var(--gradient-score-high);
   }
-
   .score-bar-mid {
     background: var(--gradient-score-mid);
   }
-
   .score-bar-low {
     background: var(--gradient-score-low);
   }
-
   .glass {
     background: hsl(0 0% 100% / 0.08);
     backdrop-filter: blur(12px);
     border: 1px solid hsl(0 0% 100% / 0.12);
   }
 
+  /* Theme semantic utilities */
+  .bg-page {
+    background-color: var(--bg-page);
+  }
+  .bg-surface {
+    background-color: var(--bg-surface);
+  }
+  .bg-surface-2 {
+    background-color: var(--bg-surface-2);
+  }
+  .border-theme {
+    border-color: var(--border-theme);
+  }
+  .bg-brand {
+    background-color: var(--brand);
+  }
+  .text-brand {
+    color: var(--brand);
+  }
+  .text-on-brand {
+    color: var(--brand-text);
+  }
+  .text-theme-primary {
+    color: var(--text-primary);
+  }
+  .text-theme-secondary {
+    color: var(--text-secondary);
+  }
+  .text-theme-muted {
+    color: var(--text-muted);
+  }
+
+  /* Animations */
   .animate-fade-up {
     animation: fade-up 0.5s ease-out both;
   }
-
   .animate-fade-in {
     animation: fade-in 0.4s ease-out both;
   }
-
   .animate-scale-in {
     animation: scale-in 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   }
-
   .animate-count-up {
     animation: count-up 1.2s ease-out both;
   }
@@ -471,34 +254,28 @@
 
 @keyframes fade-up {
   from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
+  to   { opacity: 1; transform: translateY(0); }
 }
-
 @keyframes fade-in {
   from { opacity: 0; }
-  to { opacity: 1; }
+  to   { opacity: 1; }
 }
-
 @keyframes scale-in {
   from { opacity: 0; transform: scale(0.88); }
-  to { opacity: 1; transform: scale(1); }
+  to   { opacity: 1; transform: scale(1); }
 }
-
 @keyframes count-up {
   from { opacity: 0; }
-  to { opacity: 1; }
+  to   { opacity: 1; }
 }
-
 @keyframes bar-grow {
   from { width: 0%; }
-  to { width: var(--bar-width); }
+  to   { width: var(--bar-width); }
 }
-
 @keyframes pulse-glow {
   0%, 100% { box-shadow: 0 0 0 0 hsl(172 70% 42% / 0.4); }
-  50% { box-shadow: 0 0 0 8px hsl(172 70% 42% / 0); }
+  50%      { box-shadow: 0 0 0 8px hsl(172 70% 42% / 0); }
 }
-
 .animate-pulse-glow {
   animation: pulse-glow 2s ease-in-out infinite;
 }

--- a/src/pages/AccountSettings.tsx
+++ b/src/pages/AccountSettings.tsx
@@ -1,21 +1,45 @@
 /**
- * Account Settings page — password, MFA (TOTP), Google linking, delete account.
+ * Account Settings page â appearance, password, MFA (TOTP), Google linking, delete account.
  */
 
 import { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { Shield, Smartphone, Mail, MessageSquare, Key, Trash2, Loader2, Link2, Unlink } from "lucide-react";
+import {
+  Shield,
+  Smartphone,
+  Mail,
+  MessageSquare,
+  Key,
+  Trash2,
+  Loader2,
+  Link2,
+  Unlink,
+  Palette,
+} from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuthReady } from "@/hooks/useAuthReady";
-import { enrollTOTP, verifyTOTP, unenrollFactor, listFactors, linkWithProvider } from "@/services/user/auth";
+import {
+  enrollTOTP,
+  verifyTOTP,
+  unenrollFactor,
+  listFactors,
+  linkWithProvider,
+} from "@/services/user/auth";
 import { normalizeError } from "@/lib/normalizeError";
 import { toast } from "sonner";
+import ThemeSelector from "@/components/ThemeSelector";
 
 export default function AccountSettings() {
   const navigate = useNavigate();
@@ -37,6 +61,7 @@ export default function AccountSettings() {
   // Delete
   const [deleteConfirm, setDeleteConfirm] = useState("");
   const [deleteLoading, setDeleteLoading] = useState(false);
+
   const [linkLoading, setLinkLoading] = useState<string | null>(null);
 
   useEffect(() => {
@@ -50,31 +75,46 @@ export default function AccountSettings() {
 
   const handleChangePassword = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (newPassword.length < 8) { toast.error("Password must be at least 8 characters."); return; }
-    if (newPassword !== confirmPassword) { toast.error("Passwords do not match."); return; }
-
+    if (newPassword.length < 8) {
+      toast.error("Password must be at least 8 characters.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      toast.error("Passwords do not match.");
+      return;
+    }
     setPwLoading(true);
     try {
-      const { error } = await supabase.auth.updateUser({ password: newPassword });
+      const { error } = await supabase.auth.updateUser({
+        password: newPassword,
+      });
       if (error) throw error;
       toast.success("Password updated successfully.");
-      setNewPassword(""); setConfirmPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
     } catch (e) {
       toast.error(normalizeError(e));
-    } finally { setPwLoading(false); }
+    } finally {
+      setPwLoading(false);
+    }
   };
 
   const handleEnrollTOTP = async () => {
     setMfaLoading(true);
     try {
       const result = await enrollTOTP();
-      if (result.error) { toast.error(result.error); return; }
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
       setTotpUri(result.qrUri || null);
       setTotpSecret(result.secret || null);
       setTotpFactorId(result.factorId || null);
     } catch (e) {
       toast.error(normalizeError(e));
-    } finally { setMfaLoading(false); }
+    } finally {
+      setMfaLoading(false);
+    }
   };
 
   const handleVerifyTOTP = async () => {
@@ -82,38 +122,56 @@ export default function AccountSettings() {
     setMfaLoading(true);
     try {
       const result = await verifyTOTP(totpFactorId, verifyCode);
-      if (result.error) { toast.error(result.error); return; }
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
       toast.success("Authenticator app enabled!");
-      setTotpUri(null); setTotpSecret(null); setTotpFactorId(null); setVerifyCode("");
+      setTotpUri(null);
+      setTotpSecret(null);
+      setTotpFactorId(null);
+      setVerifyCode("");
       await loadFactors();
     } catch (e) {
       toast.error(normalizeError(e));
-    } finally { setMfaLoading(false); }
+    } finally {
+      setMfaLoading(false);
+    }
   };
 
   const handleUnenroll = async (factorId: string) => {
     setMfaLoading(true);
     try {
       const result = await unenrollFactor(factorId);
-      if (result.error) { toast.error(result.error); return; }
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
       toast.success("MFA factor removed.");
       await loadFactors();
     } catch (e) {
       toast.error(normalizeError(e));
-    } finally { setMfaLoading(false); }
+    } finally {
+      setMfaLoading(false);
+    }
   };
 
   const handleDeleteAccount = async () => {
     if (deleteConfirm !== "DELETE") return;
     setDeleteLoading(true);
     try {
-      const { data: { session } } = await supabase.auth.getSession();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
       if (!session) throw new Error("Not authenticated");
       const resp = await fetch(
         `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/delete-own-account`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${session.access_token}`,
+          },
         }
       );
       if (!resp.ok) throw new Error("Failed to delete account");
@@ -121,12 +179,19 @@ export default function AccountSettings() {
       navigate("/");
     } catch (e) {
       toast.error(normalizeError(e));
-    } finally { setDeleteLoading(false); }
+    } finally {
+      setDeleteLoading(false);
+    }
   };
 
-  const activeTotpFactors = mfaFactors.filter(f => f.factor_type === "totp" && f.status === "verified");
+  const activeTotpFactors = mfaFactors.filter(
+    (f) => f.factor_type === "totp" && f.status === "verified"
+  );
 
-  const providers: string[] = useMemo(() => user?.app_metadata?.providers || [], [user]);
+  const providers: string[] = useMemo(
+    () => user?.app_metadata?.providers || [],
+    [user]
+  );
   const hasGoogle = providers.includes("google");
   const hasApple = providers.includes("apple");
   const identityCount = user?.identities?.length ?? 0;
@@ -139,7 +204,9 @@ export default function AccountSettings() {
       if (result.error) {
         toast.error(result.error);
       } else {
-        toast.success(`${provider === "google" ? "Google" : "Apple"} account linked!`);
+        toast.success(
+          `${provider === "google" ? "Google" : "Apple"} account linked!`
+        );
       }
     } catch (e) {
       toast.error(normalizeError(e));
@@ -150,20 +217,25 @@ export default function AccountSettings() {
 
   const handleUnlinkProvider = async (provider: "google" | "apple") => {
     if (!canUnlink) {
-      toast.error("Cannot unlink your only sign-in method. Add another provider or set a password first.");
+      toast.error(
+        "Cannot unlink your only sign-in method. Add another provider or set a password first."
+      );
       return;
     }
-    const identity = user?.identities?.find(i => i.provider === provider);
-    if (!identity) { toast.error("Identity not found."); return; }
-
+    const identity = user?.identities?.find((i) => i.provider === provider);
+    if (!identity) {
+      toast.error("Identity not found.");
+      return;
+    }
     setLinkLoading(provider);
     try {
       const { error } = await supabase.auth.unlinkIdentity(identity);
       if (error) {
         toast.error(normalizeError(error));
       } else {
-        toast.success(`${provider === "google" ? "Google" : "Apple"} account unlinked.`);
-        // Refresh session to update user metadata
+        toast.success(
+          `${provider === "google" ? "Google" : "Apple"} account unlinked.`
+        );
         await supabase.auth.refreshSession();
       }
     } catch (e) {
@@ -177,7 +249,22 @@ export default function AccountSettings() {
     <div className="max-w-2xl mx-auto py-8 px-4 space-y-6">
       <h1 className="text-2xl font-bold text-foreground">Account Settings</h1>
 
-      {/* Profile Info */}
+      {/* âââ Appearance âââââââââââââââââââââââââââââââââââââââââââââââââââ */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Palette className="w-4 h-4" /> Appearance
+          </CardTitle>
+          <CardDescription>
+            Customize how iCareerOS looks on your device
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ThemeSelector />
+        </CardContent>
+      </Card>
+
+      {/* âââ Account Info ââââââââââââââââââââââââââââââââââââââââââââââââââ */}
       <Card>
         <CardHeader>
           <CardTitle className="text-lg">Account Info</CardTitle>
@@ -185,558 +272,103 @@ export default function AccountSettings() {
         <CardContent className="space-y-2">
           <div className="flex justify-between items-center">
             <span className="text-sm text-muted-foreground">Email</span>
-            <span className="text-sm font-medium">{user?.email || "—"}</span>
+            <span className="text-sm font-medium">{user?.email || "â"}</span>
           </div>
           <div className="flex justify-between items-center">
-            <span className="text-sm text-muted-foreground">Auth providers</span>
+            <span className="text-sm text-muted-foreground">
+              Auth providers
+            </span>
             <div className="flex gap-1">
-/**
-               * Account Settings page — appearance, password, MFA (TOTP), Google linking, delete account.
-               */
-              
-              import { useState, useEffect, useMemo } from "react";
-              import { useNavigate } from "react-router-dom";
-              import {
-                  Card,
-                  CardContent,
-                  CardDescription,
-                  CardHeader,
-                  CardTitle,
-              } from "@/components/ui/card";
-              import { Button } from "@/components/ui/button";
-              import { Input } from "@/components/ui/input";
-              import { Label } from "@/components/ui/label";
-              import { Badge } from "@/components/ui/badge";
-              import { Separator } from "@/components/ui/separator";
-              import {
-                  Shield,
-                  Smartphone,
-                  Mail,
-                  MessageSquare,
-                  Key,
-                  Trash2,
-                  Loader2,
-                  Link2,
-                  Unlink,
-                  Palette,
-              } from "lucide-react";
-              import { supabase } from "@/integrations/supabase/client";
-              import { useAuthReady } from "@/hooks/useAuthReady";
-              import {
-                  enrollTOTP,
-                  verifyTOTP,
-                  unenrollFactor,
-                  listFactors,
-                  linkWithProvider,
-              } from "@/services/user/auth";
-              import { normalizeError } from "@/lib/normalizeError";
-              import { toast } from "sonner";
-              import ThemeSelector from "@/components/ThemeSelector";
-              
-              export default function AccountSettings() {
-                  const navigate = useNavigate();
-                const { user } = useAuthReady();
-              
-                // Password
-                const [newPassword, setNewPassword] = useState("");
-                const [confirmPassword, setConfirmPassword] = useState("");
-                const [pwLoading, setPwLoading] = useState(false);
-              
-                // MFA
-                const [mfaFactors, setMfaFactors] = useState<any[]>([]);
-                const [totpUri, setTotpUri] = useState<string | null>(null);
-                const [totpSecret, setTotpSecret] = useState<string | null>(null);
-                const [totpFactorId, setTotpFactorId] = useState<string | null>(null);
-                const [verifyCode, setVerifyCode] = useState("");
-                const [mfaLoading, setMfaLoading] = useState(false);
-              
-                // Delete
-                const [deleteConfirm, setDeleteConfirm] = useState("");
-                const [deleteLoading, setDeleteLoading] = useState(false);
-              
-                const [linkLoading, setLinkLoading] = useState<string | null>(null);
-              
-                useEffect(() => {
-                      loadFactors();
-              }, []);
-              
-                async function loadFactors() {
-                      const result = await listFactors();
-                  if (result.factors) setMfaFactors(result.factors);
-              }
-              
-                const handleChangePassword = async (e: React.FormEvent) => {
-                      e.preventDefault();
-                  if (newPassword.length < 8) {
-                          toast.error("Password must be at least 8 characters.");
-                          return;
-                    }
-                        if (newPassword !== confirmPassword) {
-                                toast.error("Passwords do not match.");
-                          return;
-                    }
-                        setPwLoading(true);
-                        try {
-                                const { error } = await supabase.auth.updateUser({
-                                          password: newPassword,
-                    });
-                          if (error) throw error;
-                          toast.success("Password updated successfully.");
-                          setNewPassword("");
-                          setConfirmPassword("");
-                    } catch (e) {
-                            toast.error(normalizeError(e));
-                    } finally {
-                            setPwLoading(false);
-                    }
-                    };
-                    
-                      const handleEnrollTOTP = async () => {
-                            setMfaLoading(true);
-                        try {
-                                const result = await enrollTOTP();
-                          if (result.error) {
-                                    toast.error(result.error);
-                            return;
-                    }
-                          setTotpUri(result.qrUri || null);
-                          setTotpSecret(result.secret || null);
-                          setTotpFactorId(result.factorId || null);
-                    } catch (e) {
-                            toast.error(normalizeError(e));
-                    } finally {
-                            setMfaLoading(false);
-                    }
-                    };
-                    
-                      const handleVerifyTOTP = async () => {
-                            if (!totpFactorId || !verifyCode) return;
-                        setMfaLoading(true);
-                        try {
-                                const result = await verifyTOTP(totpFactorId, verifyCode);
-                          if (result.error) {
-                                    toast.error(result.error);
-                            return;
-                    }
-                          toast.success("Authenticator app enabled!");
-                          setTotpUri(null);
-                          setTotpSecret(null);
-                          setTotpFactorId(null);
-                          setVerifyCode("");
-                          await loadFactors();
-                    } catch (e) {
-                            toast.error(normalizeError(e));
-                    } finally {
-                            setMfaLoading(false);
-                    }
-                    };
-                    
-                      const handleUnenroll = async (factorId: string) => {
-                            setMfaLoading(true);
-                        try {
-                                const result = await unenrollFactor(factorId);
-                          if (result.error) {
-                                    toast.error(result.error);
-                            return;
-                    }
-                          toast.success("MFA factor removed.");
-                          await loadFactors();
-                    } catch (e) {
-                            toast.error(normalizeError(e));
-                    } finally {
-                            setMfaLoading(false);
-                    }
-                    };
-                    
-                      const handleDeleteAccount = async () => {
-                            if (deleteConfirm !== "DELETE") return;
-                        setDeleteLoading(true);
-                        try {
-                                const {
-                                          data: { session },
-                                } = await supabase.auth.getSession();
-                          if (!session) throw new Error("Not authenticated");
-                          const resp = await fetch(
-                            `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/delete-own-account`,
-                    {
-                                method: "POST",
-                              headers: {
-                                            "Content-Type": "application/json",
-                                Authorization: `Bearer ${session.access_token}`,
-                    },
-                    }
-                          );
-                          if (!resp.ok) throw new Error("Failed to delete account");
-                          await supabase.auth.signOut();
-                          navigate("/");
-                    } catch (e) {
-                            toast.error(normalizeError(e));
-                    } finally {
-                            setDeleteLoading(false);
-                    }
-                    };
-                    
-                      const activeTotpFactors = mfaFactors.filter(
-                        (f) => f.factor_type === "totp" && f.status === "verified"
-                      );
-                    
-                      const providers: string[] = useMemo(
-                        () => user?.app_metadata?.providers || [],
-                        [user]
-                      );
-                      const hasGoogle = providers.includes("google");
-                      const hasApple = providers.includes("apple");
-                      const identityCount = user?.identities?.length ?? 0;
-                      const canUnlink = identityCount > 1;
-                    
-                      const handleLinkProvider = async (provider: "google" | "apple") => {
-                            setLinkLoading(provider);
-                        try {
-                                const result = await linkWithProvider(provider);
-                          if (result.error) {
-                                    toast.error(result.error);
-                    } else {
-                              toast.success(
-                                          `${provider === "google" ? "Google" : "Apple"} account linked!`
-                                        );
-                    }
-                    } catch (e) {
-                            toast.error(normalizeError(e));
-                    } finally {
-                            setLinkLoading(null);
-                    }
-                    };
-                    
-                      const handleUnlinkProvider = async (provider: "google" | "apple") => {
-                            if (!canUnlink) {
-                                    toast.error(
-                                              "Cannot unlink your only sign-in method. Add another provider or set a password first."
-                                            );
-                          return;
-                    }
-                        const identity = user?.identities?.find((i) => i.provider === provider);
-                        if (!identity) {
-                                toast.error("Identity not found.");
-                          return;
-                    }
-                        setLinkLoading(provider);
-                        try {
-                                const { error } = await supabase.auth.unlinkIdentity(identity);
-                          if (error) {
-                                    toast.error(normalizeError(error));
-                    } else {
-                              toast.success(
-                                          `${provider === "google" ? "Google" : "Apple"} account unlinked.`
-                                        );
-                            await supabase.auth.refreshSession();
-                    }
-                    } catch (e) {
-                            toast.error(normalizeError(e));
-                    } finally {
-                            setLinkLoading(null);
-                    }
-                    };
-                    
-                      return (
-                        <div className="max-w-2xl mx-auto py-8 px-4 space-y-6">
-                              <h1 className="text-2xl font-bold text-foreground">Account Settings</h1>h1>
-                        
-                          {/* ─── Appearance ─────────────────────────────────────────────────── */}
-                              <Card>
-                                      <CardHeader>
-                                                <CardTitle className="text-lg flex items-center gap-2">
-                                                            <Palette className="w-4 h-4" /> Appearance
-                                                </CardTitle>CardTitle>
-                                                <CardDescription>
-                                                            Customize how iCareerOS looks on your device
-                                                </CardDescription>CardDescription>
-                                      </CardHeader>CardHeader>
-                                      <CardContent>
-                                                <ThemeSelector />
-                                      </CardContent>CardContent>
-                              </Card>Card>
-                        
-                          {/* ─── Account Info ────────────────────────────────────────────────── */}
-                              <Card>
-                                      <CardHeader>
-                                                <CardTitle className="text-lg">Account Info</CardTitle>CardTitle>
-                                      </CardHeader>CardHeader>
-                                      <CardContent className="space-y-2">
-                                                <div className="flex justify-between items-center">
-                                                            <span className="text-sm text-muted-foreground">Email</span>span>
-                                                            <span className="text-sm font-medium">{user?.email || "—"}</span>span>
-                                                </div>div>
-                                                <div className="flex justify-between items-center">
-                                                            <span className="text-sm text-muted-foreground">
-                                                                          Auth providers
-                                                            </span>span>
-                                                            <div className="flex gap-1">
-                                                              {user?.app_metadata?.providers?.map((p: string) => (
-                      <Badge key={p} variant="secondary" className="text-xs">
-                        {p}
-                      </Badge>Badge>
-                    )) || (
-                      <Badge variant="secondary" className="text-xs">
-                                        email
-                      </Badge>Badge>
-                                                                          )}
-                                                            </div>div>
-                                                </div>div>
-                                      </CardContent>CardContent>
-                              </Card>Card>
-                        
-                          {/* ─── Connected Accounts ──────────────────────────────────────────── */}
-                              <Card>
-                                      <CardHeader>
-                                                <CardTitle className="text-lg flex items-center gap-2">
-                                                            <Link2 className="w-4 h-4" /> Connected Accounts
-                                                </CardTitle>CardTitle>
-                                                <CardDescription>
-                                                            Link social accounts for faster sign-in
-                                                </CardDescription>CardDescription>
-                                      </CardHeader>CardHeader>
-                                      <CardContent className="space-y-3">
-                                        {/* Google */}
-                                                <div className="flex items-center justify-between p-3 rounded-lg border border-border">
-                                                            <div className="flex items-center gap-3">
-                                                                          <svg
-                                                                                            className="w-5 h-5"
-                                                                                            viewBox="0 0 24 24"
-                                                                                            aria-hidden="true"
-                                                                                          >
-                                                                                          <path
-                                                                                                              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                                                                                                              fill="#4285F4"
-                                                                                                            />
-                                                                                          <path
-                                                                                                              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                                                                                                              fill="#34A853"
-                                                                                                            />
-                                                                                          <path
-                                                                                                              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                                                                                                              fill="#FBBC05"
-                                                                                                            />
-                                                                                          <path
-                                                                                                              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                                                                                                              fill="#EA4335"
-                                                                                                            />
-                                                                          </svg>svg>
-                                                                          <div>
-                                                                                          <p className="text-sm font-medium">Google</p>p>
-                                                                                          <p className="text-xs text-muted-foreground">
-                                                                                            {hasGoogle ? "Connected" : "Not connected"}
-                                                                                            </p>p>
-                                                                          </div>div>
-                                                            </div>div>
-                                                  {hasGoogle ? (
-                    <div className="flex items-center gap-2">
-                                    <Badge className="bg-primary/10 text-primary border-0">
-                                                      Linked
-                                    </Badge>Badge>
-                                    <Button
-                                                        size="sm"
-                                                        variant="outline"
-                                                        disabled={!canUnlink || linkLoading === "google"}
-                                                        onClick={() => handleUnlinkProvider("google")}
-                                                        title={
-                                                                              !canUnlink
-                                                                                ? "Cannot unlink your only sign-in method"
-                                                                                : "Unlink Google"
-                                                        }
-                                                      >
-                                      {linkLoading === "google" ? (
-                                                                            <Loader2 className="w-4 h-4 animate-spin" />
-                                                                          ) : (
-                                                                            <Unlink className="w-4 h-4" />
-                                                                          )}
-                                    </Button>Button>
-                    </div>div>
-                  ) : (
-                    <Button
-                                      size="sm"
-                                      variant="outline"
-                                      disabled={linkLoading === "google"}
-                                      onClick={() => handleLinkProvider("google")}
-                                    >
-                      {linkLoading === "google" ? (
-                                                        <Loader2 className="w-4 h-4 animate-spin mr-1" />
-                                                      ) : null}
-                                    Link
-                    </Button>Button>
-                                                            )}
-                                                </div>div>
-                                      
-                                        {/* Apple */}
-                                                <div className="flex items-center justify-between p-3 rounded-lg border border-border">
-                                                            <div className="flex items-center gap-3">
-                                                                          <svg
-                                                                                            className="w-5 h-5"
-                                                                                            viewBox="0 0 24 24"
-                                                                                            fill="currentColor"
-                                                                                            aria-hidden="true"
-                                                                                          >
-                                                                                          <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
-                                                                          </svg>svg>
-                                                                          <div>
-                                                                                          <p className="text-sm font-medium">Apple</p>p>
-                                                                                          <p className="text-xs text-muted-foreground">
-                                                                                            {hasApple ? "Connected" : "Not connected"}
-                                                                                            </p>p>
-                                                                          </div>div>
-                                                            </div>div>
-                                                  {hasApple ? (
-                    <div className="flex items-center gap-2">
-                                    <Badge className="bg-primary/10 text-primary border-0">
-                                                      Linked
-                                    </Badge>Badge>
-                                    <Button
-                                                        size="sm"
-                                                        variant="outline"
-                                                        disabled={!canUnlink || linkLoading === "apple"}
-                                                        onClick={() => handleUnlinkProvider("apple")}
-                                                        title={
-                                                                              !canUnlink
-                                                                                ? "Cannot unlink your only sign-in method"
-                                                                                : "Unlink Apple"
-                                                        }
-                                                      >
-                                      {linkLoading === "apple" ? (
-                                                                            <Loader2 className="w-4 h-4 animate-spin" />
-                                                                          ) : (
-                                                                            <Unlink className="w-4 h-4" />
-                                                                          )}
-                                    </Button>Button>
-                    </div>div>
-                  ) : (
-                    <Button
-                                      size="sm"
-                                      variant="outline"
-                                      disabled={linkLoading === "apple"}
-                                      onClick={() => handleLinkProvider("apple")}
-                                    >
-                      {linkLoading === "apple" ? (
-                                                        <Loader2 className="w-4 h-4 animate-spin mr-1" />
-                                                      ) : null}
-                                    Link
-                    </Button>Button>
-                                                            )}
-                                                </div>div>
-                                      </CardContent>CardContent>
-                              </Card>Card>
-                        
-                          {/* ─── Change Password ────────────────────────────────────────────── */}
-                              <Card>
-                                      <CardHeader>
-                                                <CardTitle className="text-lg flex items-center gap-2">
-                                                            <Key className="w-4 h-4" /> Change Password
-                                                </CardTitle>CardTitle>
-                                      </CardHeader>CardHeader>
-                                      <CardContent>
-                                                <form onSubmit={handleChangePassword} className="space-y-3">
-                                                            <div className="space-y-1">
-                                                                          <Label htmlFor="newPassword">New Password</Label>Label>
-                                                                          <Input
-                                                                                            id="newPassword"
-                                                                                            type="password"
-                                                                                            value={newPassword}
-                                                                                            onChange={(e) => setNewPassword(e.target.value)}
-                                                                                            minLength={8}
-                                                                                            placeholder="At least 8 characters"
-                                                                                          />
-                                                            </div>div>
-                                                            <div className="space-y-1">
-                                                                          <Label htmlFor="confirmNewPassword">Confirm New Password</Label>Label>
-                                                                          <Input
-                                                                                            id="confirmNewPassword"
-                                                                                            type="password"
-                                                                                            value={confirmPassword}
-                                                                                            onChange={(e) => setConfirmPassword(e.target.value)}
-                                                                                            placeholder="Repeat password"
-                                                                                          />
-                                                            </div>div>
-                                                            <Button
-                                                                            type="submit"
-                                                                            disabled={pwLoading || !newPassword || !confirmPassword}
-                                                                            size="sm"
-                                                                          >
-                                                              {pwLoading ? (
-                                                                                            <Loader2 className="w-4 h-4 animate-spin mr-1" />
-                                                                                          ) : null}
-                                                                          Update Password
-                                                            </Button>Button>
-                                                </form>form>
-                                      </CardContent>CardContent>
-                              </Card>Card>
-                        
-                          {/* ─── MFA ─────────────────────────────────────────────────────────── */}
-                              <Card>
-                                      <CardHeader>
-                                                <CardTitle className="text-lg flex items-center gap-2">
-                                                            <Shield className="w-4 h-4" /> Multi-Factor Authentication
-                                                </CardTitle>CardTitle>
-                                                <CardDescription>
-                                                            Add an extra layer of security to your account
-                                                </CardDescription>CardDescription>
-                                      </CardHeader>CardHeader>
-                                      <CardContent className="space-y-4">
-                                        {/* TOTP */}
-                                                <div className="flex items-center justify-between p-3 rounded-lg border border-border">
-                                                            <div className="flex items-center gap-3">
-                                                                          <Smartphone className="w-5 h-5 text-primary" />
-                                                                          <div>
-                                                                                          <p className="text-sm font-medium">Authenticator App</p>p>
-                                                                                          <p className="text-xs text-muted-foreground">
-                                                                                                            Google Authenticator, Microsoft Authenticator, Authy
-                                                                                            </p>p>
-                                                                          </div>div>
-                                                            </div>div>
-                                                  {activeTotpFactors.length > 0 ? (
-                    <div className="flex items-center gap-2">
-                                    <Badge className="bg-primary/10 text-primary border-0">
-                                                      Active
-                                    </Badge>Badge>
-                                    <Button
-                                                        variant="outline"
-                                         </div>{user?.app_metadata?.providers?.map((p: string) => (
-                <Badge key={p} variant="secondary" className="text-xs">{p}</Badge>
-              )) || <Badge variant="secondary" className="text-xs">email</Badge>}
+              {user?.app_metadata?.providers?.map((p: string) => (
+                <Badge key={p} variant="secondary" className="text-xs">
+                  {p}
+                </Badge>
+              )) || (
+                <Badge variant="secondary" className="text-xs">
+                  email
+                </Badge>
+              )}
             </div>
           </div>
         </CardContent>
       </Card>
 
-      {/* Connected Accounts */}
+      {/* âââ Connected Accounts ââââââââââââââââââââââââââââââââââââââââââââ */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg flex items-center gap-2"><Link2 className="w-4 h-4" /> Connected Accounts</CardTitle>
-          <CardDescription>Link social accounts for faster sign-in</CardDescription>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Link2 className="w-4 h-4" /> Connected Accounts
+          </CardTitle>
+          <CardDescription>
+            Link social accounts for faster sign-in
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
           {/* Google */}
           <div className="flex items-center justify-between p-3 rounded-lg border border-border">
             <div className="flex items-center gap-3">
-              <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
-                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+              <svg
+                className="w-5 h-5"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  fill="#EA4335"
+                />
               </svg>
               <div>
                 <p className="text-sm font-medium">Google</p>
-                <p className="text-xs text-muted-foreground">{hasGoogle ? "Connected" : "Not connected"}</p>
+                <p className="text-xs text-muted-foreground">
+                  {hasGoogle ? "Connected" : "Not connected"}
+                </p>
               </div>
             </div>
             {hasGoogle ? (
               <div className="flex items-center gap-2">
-                <Badge className="bg-primary/10 text-primary border-0">Linked</Badge>
-                <Button size="sm" variant="outline" disabled={!canUnlink || linkLoading === "google"} onClick={() => handleUnlinkProvider("google")}
-                  title={!canUnlink ? "Cannot unlink your only sign-in method" : "Unlink Google"}>
-                  {linkLoading === "google" ? <Loader2 className="w-4 h-4 animate-spin" /> : <Unlink className="w-4 h-4" />}
+                <Badge className="bg-primary/10 text-primary border-0">
+                  Linked
+                </Badge>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={!canUnlink || linkLoading === "google"}
+                  onClick={() => handleUnlinkProvider("google")}
+                  title={
+                    !canUnlink
+                      ? "Cannot unlink your only sign-in method"
+                      : "Unlink Google"
+                  }
+                >
+                  {linkLoading === "google" ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <Unlink className="w-4 h-4" />
+                  )}
                 </Button>
               </div>
             ) : (
-              <Button size="sm" variant="outline" disabled={linkLoading === "google"} onClick={() => handleLinkProvider("google")}>
-                {linkLoading === "google" ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : null}
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={linkLoading === "google"}
+                onClick={() => handleLinkProvider("google")}
+              >
+                {linkLoading === "google" ? (
+                  <Loader2 className="w-4 h-4 animate-spin mr-1" />
+                ) : null}
                 Link
               </Button>
             )}
@@ -745,25 +377,54 @@ export default function AccountSettings() {
           {/* Apple */}
           <div className="flex items-center justify-between p-3 rounded-lg border border-border">
             <div className="flex items-center gap-3">
-              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
+              <svg
+                className="w-5 h-5"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
               </svg>
               <div>
                 <p className="text-sm font-medium">Apple</p>
-                <p className="text-xs text-muted-foreground">{hasApple ? "Connected" : "Not connected"}</p>
+                <p className="text-xs text-muted-foreground">
+                  {hasApple ? "Connected" : "Not connected"}
+                </p>
               </div>
             </div>
             {hasApple ? (
               <div className="flex items-center gap-2">
-                <Badge className="bg-primary/10 text-primary border-0">Linked</Badge>
-                <Button size="sm" variant="outline" disabled={!canUnlink || linkLoading === "apple"} onClick={() => handleUnlinkProvider("apple")}
-                  title={!canUnlink ? "Cannot unlink your only sign-in method" : "Unlink Apple"}>
-                  {linkLoading === "apple" ? <Loader2 className="w-4 h-4 animate-spin" /> : <Unlink className="w-4 h-4" />}
+                <Badge className="bg-primary/10 text-primary border-0">
+                  Linked
+                </Badge>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={!canUnlink || linkLoading === "apple"}
+                  onClick={() => handleUnlinkProvider("apple")}
+                  title={
+                    !canUnlink
+                      ? "Cannot unlink your only sign-in method"
+                      : "Unlink Apple"
+                  }
+                >
+                  {linkLoading === "apple" ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <Unlink className="w-4 h-4" />
+                  )}
                 </Button>
               </div>
             ) : (
-              <Button size="sm" variant="outline" disabled={linkLoading === "apple"} onClick={() => handleLinkProvider("apple")}>
-                {linkLoading === "apple" ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : null}
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={linkLoading === "apple"}
+                onClick={() => handleLinkProvider("apple")}
+              >
+                {linkLoading === "apple" ? (
+                  <Loader2 className="w-4 h-4 animate-spin mr-1" />
+                ) : null}
                 Link
               </Button>
             )}
@@ -771,53 +432,91 @@ export default function AccountSettings() {
         </CardContent>
       </Card>
 
-      {/* Change Password */}
+      {/* âââ Change Password ââââââââââââââââââââââââââââââââââââââââââââââ */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg flex items-center gap-2"><Key className="w-4 h-4" /> Change Password</CardTitle>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Key className="w-4 h-4" /> Change Password
+          </CardTitle>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleChangePassword} className="space-y-3">
             <div className="space-y-1">
               <Label htmlFor="newPassword">New Password</Label>
-              <Input id="newPassword" type="password" value={newPassword} onChange={e => setNewPassword(e.target.value)} minLength={8} placeholder="At least 8 characters" />
+              <Input
+                id="newPassword"
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                minLength={8}
+                placeholder="At least 8 characters"
+              />
             </div>
             <div className="space-y-1">
               <Label htmlFor="confirmNewPassword">Confirm New Password</Label>
-              <Input id="confirmNewPassword" type="password" value={confirmPassword} onChange={e => setConfirmPassword(e.target.value)} placeholder="Repeat password" />
+              <Input
+                id="confirmNewPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder="Repeat password"
+              />
             </div>
-            <Button type="submit" disabled={pwLoading || !newPassword || !confirmPassword} size="sm">
-              {pwLoading ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : null}
+            <Button
+              type="submit"
+              disabled={pwLoading || !newPassword || !confirmPassword}
+              size="sm"
+            >
+              {pwLoading ? (
+                <Loader2 className="w-4 h-4 animate-spin mr-1" />
+              ) : null}
               Update Password
             </Button>
           </form>
         </CardContent>
       </Card>
 
-      {/* MFA */}
+      {/* âââ MFA âââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg flex items-center gap-2"><Shield className="w-4 h-4" /> Multi-Factor Authentication</CardTitle>
-          <CardDescription>Add an extra layer of security to your account</CardDescription>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Shield className="w-4 h-4" /> Multi-Factor Authentication
+          </CardTitle>
+          <CardDescription>
+            Add an extra layer of security to your account
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {/* TOTP — fully supported */}
+          {/* TOTP */}
           <div className="flex items-center justify-between p-3 rounded-lg border border-border">
             <div className="flex items-center gap-3">
               <Smartphone className="w-5 h-5 text-primary" />
               <div>
                 <p className="text-sm font-medium">Authenticator App</p>
-                <p className="text-xs text-muted-foreground">Google Authenticator, Microsoft Authenticator, Authy</p>
+                <p className="text-xs text-muted-foreground">
+                  Google Authenticator, Microsoft Authenticator, Authy
+                </p>
               </div>
             </div>
             {activeTotpFactors.length > 0 ? (
               <div className="flex items-center gap-2">
-                <Badge className="bg-primary/10 text-primary border-0">Active</Badge>
-                <Button variant="outline" size="sm" onClick={() => handleUnenroll(activeTotpFactors[0].id)} disabled={mfaLoading}>Remove</Button>
+                <Badge className="bg-primary/10 text-primary border-0">
+                  Active
+                </Badge>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleUnenroll(activeTotpFactors[0].id)}
+                  disabled={mfaLoading}
+                >
+                  Remove
+                </Button>
               </div>
             ) : (
               <Button size="sm" onClick={handleEnrollTOTP} disabled={mfaLoading}>
-                {mfaLoading ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : null}
+                {mfaLoading ? (
+                  <Loader2 className="w-4 h-4 animate-spin mr-1" />
+                ) : null}
                 Enable
               </Button>
             )}
@@ -826,63 +525,113 @@ export default function AccountSettings() {
           {/* TOTP enrollment flow */}
           {totpUri && (
             <div className="p-4 rounded-lg border border-border bg-muted/30 space-y-3">
-              <p className="text-sm font-medium">Scan this QR code with your authenticator app:</p>
+              <p className="text-sm font-medium">
+                Scan this QR code with your authenticator app:
+              </p>
               <div className="flex justify-center">
-                <img src={totpUri} alt="TOTP QR Code" className="w-48 h-48" />
+                <img
+                  src={totpUri}
+                  alt="TOTP QR Code"
+                  className="w-48 h-48"
+                />
               </div>
               {totpSecret && (
                 <p className="text-xs text-muted-foreground text-center">
-                  Manual entry: <code className="bg-muted px-1 rounded text-xs">{totpSecret}</code>
+                  Manual entry:{" "}
+                  <code className="bg-muted px-1 rounded text-xs">
+                    {totpSecret}
+                  </code>
                 </p>
               )}
               <div className="flex gap-2">
-                <Input placeholder="Enter 6-digit code" value={verifyCode} onChange={e => setVerifyCode(e.target.value)} maxLength={6} />
-                <Button size="sm" onClick={handleVerifyTOTP} disabled={mfaLoading || verifyCode.length !== 6}>Verify</Button>
+                <Input
+                  placeholder="Enter 6-digit code"
+                  value={verifyCode}
+                  onChange={(e) => setVerifyCode(e.target.value)}
+                  maxLength={6}
+                />
+                <Button
+                  size="sm"
+                  onClick={handleVerifyTOTP}
+                  disabled={mfaLoading || verifyCode.length !== 6}
+                >
+                  Verify
+                </Button>
               </div>
             </div>
           )}
 
           <Separator />
 
-          {/* Email MFA — grayed out */}
+          {/* Email MFA â grayed out */}
           <div className="flex items-center justify-between p-3 rounded-lg border border-border opacity-50">
             <div className="flex items-center gap-3">
               <Mail className="w-5 h-5 text-muted-foreground" />
               <div>
-                <p className="text-sm font-medium text-muted-foreground">Email Verification</p>
-                <p className="text-xs text-muted-foreground">Receive codes via email</p>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Email Verification
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Receive codes via email
+                </p>
               </div>
             </div>
-            <Badge variant="outline" className="text-xs">Coming soon</Badge>
+            <Badge variant="outline" className="text-xs">
+              Coming soon
+            </Badge>
           </div>
 
-          {/* SMS MFA — grayed out */}
+          {/* SMS MFA â grayed out */}
           <div className="flex items-center justify-between p-3 rounded-lg border border-border opacity-50">
             <div className="flex items-center gap-3">
               <MessageSquare className="w-5 h-5 text-muted-foreground" />
               <div>
-                <p className="text-sm font-medium text-muted-foreground">SMS Verification</p>
-                <p className="text-xs text-muted-foreground">Receive codes via text message</p>
+                <p className="text-sm font-medium text-muted-foreground">
+                  SMS Verification
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Receive codes via text message
+                </p>
               </div>
             </div>
-            <Badge variant="outline" className="text-xs">Coming soon</Badge>
+            <Badge variant="outline" className="text-xs">
+              Coming soon
+            </Badge>
           </div>
         </CardContent>
       </Card>
 
-      {/* Delete Account */}
+      {/* âââ Delete Account ââââââââââââââââââââââââââââââââââââââââââââââââ */}
       <Card className="border-destructive/30">
         <CardHeader>
-          <CardTitle className="text-lg text-destructive flex items-center gap-2"><Trash2 className="w-4 h-4" /> Delete Account</CardTitle>
-          <CardDescription>Permanently delete your account and all associated data. This action cannot be undone.</CardDescription>
+          <CardTitle className="text-lg text-destructive flex items-center gap-2">
+            <Trash2 className="w-4 h-4" /> Delete Account
+          </CardTitle>
+          <CardDescription>
+            Permanently delete your account and all associated data. This action
+            cannot be undone.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
           <div className="space-y-1">
-            <Label htmlFor="deleteConfirm" className="text-sm">Type <strong>DELETE</strong> to confirm</Label>
-            <Input id="deleteConfirm" value={deleteConfirm} onChange={e => setDeleteConfirm(e.target.value)} placeholder="DELETE" />
+            <Label htmlFor="deleteConfirm" className="text-sm">
+              Type <strong>DELETE</strong> to confirm
+            </Label>
+            <Input
+              id="deleteConfirm"
+              value={deleteConfirm}
+              onChange={(e) => setDeleteConfirm(e.target.value)}
+              placeholder="DELETE"
+            />
           </div>
-          <Button variant="destructive" disabled={deleteConfirm !== "DELETE" || deleteLoading} onClick={handleDeleteAccount}>
-            {deleteLoading ? <Loader2 className="w-4 h-4 animate-spin mr-1" /> : null}
+          <Button
+            variant="destructive"
+            disabled={deleteConfirm !== "DELETE" || deleteLoading}
+            onClick={handleDeleteAccount}
+          >
+            {deleteLoading ? (
+              <Loader2 className="w-4 h-4 animate-spin mr-1" />
+            ) : null}
             Permanently Delete Account
           </Button>
         </CardContent>


### PR DESCRIPTION
## Summary

- Adds complete light/dark/auto theme system using `data-theme` attribute on `<html>` and CSS variables
- - ThemeContext provider with Supabase persistence (`user_profiles.theme` column)
- - ThemeSelector component with mini-UI preview cards for Light, Dark, and Automatic modes
- - OrbitalLogo SVG component and favicon.svg with theme-aware brand colors
- - Tailwind dark mode configured via `darkMode: ["selector", "[data-theme=\"dark\"]"]`
- - Appearance section added to Account Settings page
## Files changed

- `src/index.css` — CSS variables for light/dark themes, utility classes, keyframes
- - `src/pages/AccountSettings.tsx` — Added Appearance card with ThemeSelector
- - `src/components/ThemeSelector.tsx` — Three-card theme picker with previews
- - `src/components/OrbitalLogo.tsx` — Theme-aware orbital SVG logo
- - `public/favicon.svg` — Theme-aware favicon with `prefers-color-scheme`
## Post-merge steps

- [ ] Run `supabase db push` to apply the `20260412_user_theme_preference.sql` migration
- [ ] - [ ] Verify theme switching at `/settings`