### PR TITLE
feat: Invite System v2 — Magic Links + Platform Settings

### DIFF
--- a/src/components/career/ReferralProgram.tsx
+++ b/src/components/career/ReferralProgram.tsx
@@ -1,0 +1,506 @@
+// src/components/career/ReferralProgram.tsx
+// Referral Program section for the Career Profile page.
+// Replaces the standalone /invites route â this is embedded directly
+// in the user's career profile under "Referral Program."
+
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { toast } from "sonner";
+import {
+  Loader2,
+  Mail,
+  Copy,
+  Check,
+  RefreshCw,
+  Send,
+  Users,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  Link as LinkIcon,
+  Gift,
+  TrendingUp,
+  UserPlus,
+} from "lucide-react";
+
+interface Invitation {
+  id: string;
+  invite_type: "email" | "code";
+  invitee_email: string | null;
+  invite_code: string | null;
+  token: string;
+  status: "pending" | "accepted" | "expired" | "revoked";
+  created_at: string;
+  expires_at: string;
+}
+
+const DAILY_LIMIT = 5;
+
+export default function ReferralProgram() {
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [isSendingEmail, setIsSendingEmail] = useState(false);
+  const [isGeneratingCode, setIsGeneratingCode] = useState(false);
+  const [invitesRemaining, setInvitesRemaining] = useState(DAILY_LIMIT);
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [referralCount, setReferralCount] = useState(0);
+  const [activeCode, setActiveCode] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [copiedLink, setCopiedLink] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [userReferralCode, setUserReferralCode] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+
+      // Fetch user's invitations
+      const { data: invites } = await supabase
+        .from("invitations")
+        .select("*")
+        .eq("inviter_id", user.id)
+        .order("created_at", { ascending: false });
+
+      setInvitations(invites || []);
+
+      // Calculate today's remaining
+      const today = new Date().toISOString().split("T")[0];
+      const todayCount = (invites || []).filter((inv) =>
+        inv.created_at.startsWith(today)
+      ).length;
+      setInvitesRemaining(Math.max(0, DAILY_LIMIT - todayCount));
+
+      // Find active code invite
+      const activeCodeInvite = (invites || []).find(
+        (inv) => inv.invite_type === "code" && inv.status === "pending"
+      );
+      setActiveCode(activeCodeInvite?.invite_code || null);
+
+      // Fetch direct referral count
+      const { count } = await supabase
+        .from("referral_tree")
+        .select("id", { count: "exact", head: true })
+        .eq("invited_by", user.id);
+
+      setReferralCount(count || 0);
+
+      // Fetch user's own referral code
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("referral_code")
+        .eq("user_id", user.id)
+        .single();
+
+      setUserReferralCode(profile?.referral_code || null);
+    } catch (err) {
+      console.error("Error fetching referral data:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  async function handleSendEmailInvite(e: React.FormEvent) {
+    e.preventDefault();
+    if (!inviteEmail.trim() || invitesRemaining <= 0) return;
+
+    setIsSendingEmail(true);
+    try {
+      const { data, error } = await supabase.functions.invoke("send-invite", {
+        body: { type: "email", email: inviteEmail.trim() },
+      });
+
+      if (error) {
+        toast.error("Failed to send invite", { description: error.message });
+        return;
+      }
+
+      if (data?.error) {
+        toast.error(data.error);
+        return;
+      }
+
+      toast.success(`Magic link sent to ${inviteEmail}`, {
+        description: "They'll receive an email to complete registration.",
+      });
+      setInviteEmail("");
+      setInvitesRemaining(data.invites_remaining_today ?? invitesRemaining - 1);
+      fetchData();
+    } catch {
+      toast.error("Something went wrong. Please try again.");
+    } finally {
+      setIsSendingEmail(false);
+    }
+  }
+
+  async function handleGenerateCode() {
+    if (invitesRemaining <= 0) return;
+
+    setIsGeneratingCode(true);
+    try {
+      const { data, error } = await supabase.functions.invoke("send-invite", {
+        body: { type: "code" },
+      });
+
+      if (error) {
+        toast.error("Failed to generate code", { description: error.message });
+        return;
+      }
+
+      if (data?.error) {
+        toast.error(data.error);
+        return;
+      }
+
+      setActiveCode(data.invite_code);
+      setInvitesRemaining(data.invites_remaining_today ?? invitesRemaining - 1);
+      toast.success("New invite code generated!");
+      fetchData();
+    } catch {
+      toast.error("Something went wrong. Please try again.");
+    } finally {
+      setIsGeneratingCode(false);
+    }
+  }
+
+  function handleCopyCode() {
+    if (!activeCode) return;
+    navigator.clipboard.writeText(activeCode);
+    setCopied(true);
+    toast.success("Code copied to clipboard!");
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  function handleCopyLink() {
+    const pendingToken = invitations.find(
+      (inv) => inv.status === "pending" && inv.invite_type === "code"
+    );
+    if (pendingToken) {
+      const url = `${window.location.origin}/auth/signup?invite=${pendingToken.token}`;
+      navigator.clipboard.writeText(url);
+      setCopiedLink(true);
+      toast.success("Invite link copied!");
+      setTimeout(() => setCopiedLink(false), 2000);
+    }
+  }
+
+  const statusConfig: Record<
+    string,
+    { label: string; color: string; icon: typeof CheckCircle2 }
+  > = {
+    pending: {
+      label: "Pending",
+      color: "bg-[#00B8A9]/10 text-[#00B8A9] border-[#00B8A9]/20",
+      icon: Clock,
+    },
+    accepted: {
+      label: "Joined",
+      color: "bg-green-500/10 text-green-600 border-green-500/20",
+      icon: CheckCircle2,
+    },
+    expired: {
+      label: "Expired",
+      color: "bg-gray-500/10 text-gray-500 border-gray-500/20",
+      icon: XCircle,
+    },
+    revoked: {
+      label: "Revoked",
+      color: "bg-red-500/10 text-red-500 border-red-500/20",
+      icon: XCircle,
+    },
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[200px]">
+        <Loader2 className="h-6 w-6 animate-spin text-[#00B8A9]" />
+      </div>
+    );
+  }
+
+  const limitReached = invitesRemaining <= 0;
+  const acceptedCount = invitations.filter(
+    (i) => i.status === "accepted"
+  ).length;
+  const pendingCount = invitations.filter(
+    (i) => i.status === "pending"
+  ).length;
+
+  return (
+    <div className="space-y-6">
+      {/* Section Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#00B8A9]/10">
+            <Gift className="h-5 w-5 text-[#00B8A9]" />
+          </div>
+          <div>
+            <h2 className="text-xl font-semibold">Referral Program</h2>
+            <p className="text-sm text-muted-foreground">
+              Invite colleagues and grow your professional network
+            </p>
+          </div>
+        </div>
+        {userReferralCode && (
+          <Badge
+            variant="outline"
+            className="bg-[#F5A623]/10 text-[#F5A623] border-[#F5A623]/20 font-mono"
+          >
+            Your Code: {userReferralCode}
+          </Badge>
+        )}
+      </div>
+
+      {/* Stats Row */}
+      <div className="grid grid-cols-4 gap-4">
+        <Card>
+          <CardContent className="pt-5 pb-4 text-center">
+            <div className="text-2xl font-bold">{invitations.length}</div>
+            <div className="text-xs text-muted-foreground mt-1">Total Sent</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-5 pb-4 text-center">
+            <div className="text-2xl font-bold text-green-600">
+              {acceptedCount}
+            </div>
+            <div className="text-xs text-muted-foreground mt-1">Joined</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-5 pb-4 text-center">
+            <div className="text-2xl font-bold text-[#F5A623]">
+              {pendingCount}
+            </div>
+            <div className="text-xs text-muted-foreground mt-1">Pending</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-5 pb-4 text-center">
+            <div className="text-2xl font-bold text-[#00B8A9]">
+              {referralCount}
+            </div>
+            <div className="text-xs text-muted-foreground mt-1 flex items-center justify-center gap-1">
+              <Users className="h-3 w-3" />
+              Network
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Daily Limit */}
+      <Card>
+        <CardContent className="pt-5 pb-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-medium">Daily Invites Remaining</span>
+            <span className="text-lg font-bold text-[#00B8A9]">
+              {invitesRemaining}
+              <span className="text-xs font-normal text-muted-foreground">
+                {" "}
+                / {DAILY_LIMIT}
+              </span>
+            </span>
+          </div>
+          <Progress
+            value={(invitesRemaining / DAILY_LIMIT) * 100}
+            className="h-1.5"
+          />
+        </CardContent>
+      </Card>
+
+      {/* Invite Tabs */}
+      <Tabs defaultValue="email" className="w-full">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="email" className="flex items-center gap-2">
+            <Mail className="h-4 w-4" />
+            Invite by Email
+          </TabsTrigger>
+          <TabsTrigger value="code" className="flex items-center gap-2">
+            <LinkIcon className="h-4 w-4" />
+            Share a Code
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Email Invite Tab */}
+        <TabsContent value="email">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <UserPlus className="h-4 w-4 text-[#00B8A9]" />
+                Send Email Invitation
+              </CardTitle>
+              <CardDescription>
+                They'll receive a magic link to register directly with this
+                email address. No password setup needed.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleSendEmailInvite} className="flex gap-2">
+                <Input
+                  type="email"
+                  placeholder="colleague@company.com"
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  disabled={limitReached || isSendingEmail}
+                  className="flex-1"
+                />
+                <Button
+                  type="submit"
+                  className="bg-[#00B8A9] hover:bg-[#00A89A] text-white shrink-0"
+                  disabled={
+                    limitReached || isSendingEmail || !inviteEmail.trim()
+                  }
+                >
+                  {isSendingEmail ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Send className="h-4 w-4" />
+                  )}
+                  <span className="ml-2 hidden sm:inline">
+                    {limitReached ? "Limit Reached" : "Send"}
+                  </span>
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Code Tab */}
+        <TabsContent value="code">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <LinkIcon className="h-4 w-4 text-[#F5A623]" />
+                Shareable Invite Code
+              </CardTitle>
+              <CardDescription>
+                Share this code via text, DM, or anywhere. They'll enter it at
+                signup.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {activeCode ? (
+                <>
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 bg-muted rounded-lg px-4 py-3 text-center font-mono text-xl tracking-widest font-bold">
+                      {activeCode}
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={handleCopyCode}
+                      className="shrink-0"
+                    >
+                      {copied ? (
+                        <Check className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleCopyLink}
+                    className="w-full text-muted-foreground"
+                  >
+                    {copiedLink ? (
+                      <Check className="mr-2 h-3.5 w-3.5 text-green-500" />
+                    ) : (
+                      <LinkIcon className="mr-2 h-3.5 w-3.5" />
+                    )}
+                    Copy invite link instead
+                  </Button>
+                </>
+              ) : (
+                <div className="text-center py-2">
+                  <p className="text-sm text-muted-foreground mb-3">
+                    No active code. Generate one to share.
+                  </p>
+                </div>
+              )}
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={handleGenerateCode}
+                disabled={limitReached || isGeneratingCode}
+              >
+                {isGeneratingCode ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                )}
+                Generate New Code
+              </Button>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      {/* Invite History */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base flex items-center gap-2">
+              <TrendingUp className="h-4 w-4" />
+              Invite History
+            </CardTitle>
+            <Button variant="ghost" size="sm" onClick={fetchData}>
+              <RefreshCw className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {invitations.length === 0 ? (
+            <p className="text-center text-muted-foreground py-6 text-sm">
+              No invitations sent yet. Start growing your network!
+            </p>
+          ) : (
+            <div className="space-y-2 max-h-[300px] overflow-y-auto">
+              {invitations.slice(0, 20).map((inv) => {
+                const config = statusConfig[inv.status];
+                const StatusIcon = config.icon;
+                return (
+                  <div
+                    key={inv.id}
+                    className="flex items-center justify-between p-3 rounded-lg border"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <StatusIcon className="h-4 w-4 text-muted-foreground shrink-0" />
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium truncate">
+                          {inv.invite_type === "email"
+                            ? inv.invitee_email
+                            : `Code: ${inv.invite_code}`}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {inv.invite_type === "email" ? "Email" : "Code"}{" "}
+                          &middot;{" "}
+                          {new Date(inv.created_at).toLocaleDateString()}
+                        </div>
+                      </div>
+                    </div>
+                    <Badge variant="outline" className={config.color}>
+                      {config.label}
+                    </Badge>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/api/invites.ts
+++ b/src/lib/api/invites.ts
@@ -1,4 +1,4 @@
-// src/lib/api/invites.ts
+// src/lib/api/invites.ts (v2)
 // API utilities for the invite system.
 
 import { supabase } from "@/integrations/supabase/client";
@@ -87,5 +87,23 @@ export async function fetchAdminInviteDashboard() {
   );
 
   if (error) throw error;
+  return data;
+}
+
+/**
+ * Check the current registration mode (public or invite-only).
+ * Can be called without auth (uses anon key).
+ */
+export async function checkRegistrationMode(): Promise<{
+  invite_only: boolean;
+  mode: "invite_only" | "public";
+}> {
+  const { data, error } = await supabase.rpc("check_registration_mode");
+
+  if (error) {
+    // Default to invite-only if check fails
+    return { invite_only: true, mode: "invite_only" };
+  }
+
   return data;
 }

--- a/src/pages/admin/PlatformSettings.tsx
+++ b/src/pages/admin/PlatformSettings.tsx
@@ -1,0 +1,332 @@
+// src/pages/admin/PlatformSettings.tsx
+// Admin Platform Settings page with registration mode toggle.
+// Controls whether the platform is open (public) or invite-only.
+
+import { useState, useEffect } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { toast } from "sonner";
+import {
+  Loader2,
+  Shield,
+  Globe,
+  Lock,
+  Users,
+  Settings,
+  AlertTriangle,
+  CheckCircle2,
+  Info,
+} from "lucide-react";
+
+export default function PlatformSettings() {
+  const [isInviteOnly, setIsInviteOnly] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [stats, setStats] = useState({
+    totalUsers: 0,
+    pendingInvites: 0,
+    totalInvitesSent: 0,
+  });
+
+  useEffect(() => {
+    fetchSettings();
+  }, []);
+
+  async function fetchSettings() {
+    try {
+      // Fetch the invite_only_enrollment feature flag
+      const { data: flag } = await supabase
+        .from("feature_flags")
+        .select("enabled")
+        .eq("key", "invite_only_enrollment")
+        .single();
+
+      if (flag) {
+        setIsInviteOnly(flag.enabled);
+      }
+
+      // Fetch platform stats
+      const [usersResult, pendingResult, totalResult] = await Promise.all([
+        supabase
+          .from("profiles")
+          .select("user_id", { count: "exact", head: true }),
+        supabase
+          .from("invitations")
+          .select("id", { count: "exact", head: true })
+          .eq("status", "pending"),
+        supabase
+          .from("invitations")
+          .select("id", { count: "exact", head: true }),
+      ]);
+
+      setStats({
+        totalUsers: usersResult.count || 0,
+        pendingInvites: pendingResult.count || 0,
+        totalInvitesSent: totalResult.count || 0,
+      });
+    } catch (err) {
+      console.error("Error fetching settings:", err);
+      toast.error("Failed to load platform settings");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function handleToggleMode(enabled: boolean) {
+    setIsSaving(true);
+    try {
+      const { error } = await supabase
+        .from("feature_flags")
+        .update({ enabled, updated_at: new Date().toISOString() })
+        .eq("key", "invite_only_enrollment");
+
+      if (error) {
+        toast.error("Failed to update setting", { description: error.message });
+        return;
+      }
+
+      setIsInviteOnly(enabled);
+      toast.success(
+        enabled
+          ? "Platform switched to Invite-Only mode"
+          : "Platform switched to Public Access mode",
+        {
+          description: enabled
+            ? "New users must have a valid invite to register."
+            : "Anyone can now register on the platform.",
+        }
+      );
+    } catch {
+      toast.error("Something went wrong. Please try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <Loader2 className="h-8 w-8 animate-spin text-[#00B8A9]" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6 p-4 md:p-6">
+      {/* Page Header */}
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#00B8A9]/10">
+          <Settings className="h-5 w-5 text-[#00B8A9]" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold">Platform Settings</h1>
+          <p className="text-muted-foreground text-sm">
+            Manage registration access and platform-wide configurations
+          </p>
+        </div>
+      </div>
+
+      {/* Registration Mode Card */}
+      <Card className="border-2 border-[#00B8A9]/20">
+        <CardHeader>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Shield className="h-5 w-5 text-[#00B8A9]" />
+            Registration Access Control
+          </CardTitle>
+          <CardDescription>
+            Control how new users can join the platform
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Current Mode Display */}
+          <div className="flex items-center justify-between p-4 rounded-lg bg-muted/50">
+            <div className="flex items-center gap-3">
+              {isInviteOnly ? (
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#F5A623]/10">
+                  <Lock className="h-5 w-5 text-[#F5A623]" />
+                </div>
+              ) : (
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-500/10">
+                  <Globe className="h-5 w-5 text-green-600" />
+                </div>
+              )}
+              <div>
+                <div className="font-semibold text-base">
+                  {isInviteOnly ? "Invite-Only Mode" : "Public Access Mode"}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {isInviteOnly
+                    ? "Only users with a valid invite can register"
+                    : "Anyone can register and use the platform"}
+                </div>
+              </div>
+            </div>
+            <Badge
+              variant="outline"
+              className={
+                isInviteOnly
+                  ? "bg-[#F5A623]/10 text-[#F5A623] border-[#F5A623]/20"
+                  : "bg-green-500/10 text-green-600 border-green-500/20"
+              }
+            >
+              {isInviteOnly ? "Restricted" : "Open"}
+            </Badge>
+          </div>
+
+          {/* Toggle Switch */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <Label
+                htmlFor="invite-only-toggle"
+                className="text-sm font-medium"
+              >
+                Enable Invite-Only Registration
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                When enabled, users must have an invite code or email invitation
+                to sign up
+              </p>
+            </div>
+            <Switch
+              id="invite-only-toggle"
+              checked={isInviteOnly}
+              onCheckedChange={handleToggleMode}
+              disabled={isSaving}
+            />
+          </div>
+
+          <Separator />
+
+          {/* Mode Descriptions */}
+          <div className="grid md:grid-cols-2 gap-4">
+            {/* Invite-Only Description */}
+            <div
+              className={`p-4 rounded-lg border-2 transition-colors ${
+                isInviteOnly
+                  ? "border-[#F5A623]/40 bg-[#F5A623]/5"
+                  : "border-muted"
+              }`}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <Lock className="h-4 w-4 text-[#F5A623]" />
+                <span className="font-medium text-sm">Invite-Only</span>
+                {isInviteOnly && (
+                  <CheckCircle2 className="h-3.5 w-3.5 text-[#F5A623] ml-auto" />
+                )}
+              </div>
+              <ul className="space-y-1.5 text-xs text-muted-foreground">
+                <li className="flex items-start gap-1.5">
+                  <span className="mt-0.5">â¢</span>
+                  Users receive email invitations with magic links
+                </li>
+                <li className="flex items-start gap-1.5">
+                  <span className="mt-0.5">â¢</span>
+                  Shareable invite codes for word-of-mouth growth
+                </li>
+                <li className="flex items-start gap-1.5">
+                  <span className="mt-0.5">â¢</span>
+                  Full referral chain tracking & analytics
+                </li>
+                <li className="flex items-start gap-1.5">
+                  <span className="mt-0.5">â¢</span>
+                  Daily invite limits (5/day per user, unlimited for admins)
+                </li>
+              </ul>
+            </div>
+
+            {/* Public Access Description */}
+            <div
+              className={`p-4 rounded-lg border-2 transition-colors ${
+                !isInviteOnly
+                  ? "border-green-500/40 bg-green-500/5"
+                  : "border-muted"
+              }`}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <Globe className="h-4 w-4 text-green-600" />
+                <span className="font-medium text-sm">Public Access</span>
+                {!isInviteOnly && (
+                  <CheckCircle2 className="h-3.5 w-3.5 text-green-600 ml-auto" />
+                )}
+              </div>
+              <ul className="space-y-1.5 text-xs text-muted-foreground">
+                <li className="flex items-start gap-1.5">
+                  <span className="mt-0.5">â¢</span>
+                  Anyone can register with email or OAuth
+                </li>
+                <li className="flex items-start gap-1.5">
+                  <span className="mt-0.5">â¢</span>
+                  No invite code or link required
+                </li>
+                <li className="flex items-start gap-1.5">
+                  <span className="mt-0.5">â¢</span>
+                  Referral tracking still works for users who share codes
+                </li>
+                <li className="flex items-start gap-1.5">
+                  <span className="mt-0.5">â¢</span>
+                  Best for open launch or growth phases
+                </li>
+              </ul>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Quick Stats */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Users className="h-4 w-4" />
+            Registration Overview
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-3 gap-4">
+            <div className="text-center p-3 rounded-lg bg-muted/50">
+              <div className="text-2xl font-bold">{stats.totalUsers}</div>
+              <div className="text-xs text-muted-foreground mt-1">
+                Total Users
+              </div>
+            </div>
+            <div className="text-center p-3 rounded-lg bg-muted/50">
+              <div className="text-2xl font-bold text-[#00B8A9]">
+                {stats.totalInvitesSent}
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">
+                Invites Sent
+              </div>
+            </div>
+            <div className="text-center p-3 rounded-lg bg-muted/50">
+              <div className="text-2xl font-bold text-[#F5A623]">
+                {stats.pendingInvites}
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">
+                Pending Invites
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Info Note */}
+      <div className="flex items-start gap-3 p-4 rounded-lg bg-blue-500/5 border border-blue-500/20">
+        <Info className="h-4 w-4 text-blue-500 mt-0.5 shrink-0" />
+        <div className="text-sm text-muted-foreground">
+          <strong className="text-foreground">How it works:</strong> When
+          invite-only mode is active, the signup page requires a valid invite
+          token or code. Existing users can send invites from the{" "}
+          <strong>Referral Program</strong> section in their career profile.
+          Email invitations send a magic link â the recipient clicks it and
+          completes registration using the invited email address. In public
+          access mode, the invite gate is bypassed and anyone can register
+          directly.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/auth/SignUpWithInvite.tsx
+++ b/src/pages/auth/SignUpWithInvite.tsx
@@ -1,31 +1,55 @@
-// src/pages/auth/SignUpWithInvite.tsx
-// Modified signup page that gates registration behind a valid invite.
-// This replaces or wraps the existing signup page.
-//
-// Integration: In your existing SignUp page, wrap the form with the InviteGate
-// component, or replace the page entirely with this one.
+// src/pages/auth/SignUpWithInvite.tsx (v2)
+// Unified signup page that handles three modes:
+//   1. Magic link arrival (?invite=TOKEN&email=...&magic=1)
+//      â Auto-validates invite, signs in via OTP, accepts invite
+//   2. Invite-only mode (feature flag enabled)
+//      â Shows InviteGate, then signup form
+//   3. Public access mode (feature flag disabled)
+//      â Shows standard signup form (no invite required)
 
-import { useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { toast } from "sonner";
-import { Loader2, Eye, EyeOff } from "lucide-react";
+import { Loader2, Eye, EyeOff, Mail, CheckCircle2 } from "lucide-react";
 import { InviteGate, InvitedByBadge } from "@/components/invite/InviteGate";
 import type { InvitationData } from "@/components/invite/InviteGate";
 
+type RegistrationMode = "loading" | "invite_only" | "public";
+type SignupStep = "gate" | "magic_link" | "form" | "magic_complete";
+
 export default function SignUpWithInvite() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // Registration mode (controlled by admin toggle)
+  const [regMode, setRegMode] = useState<RegistrationMode>("loading");
+
+  // Which step of the flow we're on
+  const [step, setStep] = useState<SignupStep>("gate");
 
   // Invite state
-  const [inviteValidated, setInviteValidated] = useState(false);
-  const [invitationData, setInvitationData] = useState<InvitationData | null>(null);
+  const [invitationData, setInvitationData] = useState<InvitationData | null>(
+    null
+  );
 
-  // Form state
+  // Magic link state
+  const [magicLinkEmail, setMagicLinkEmail] = useState("");
+  const [isMagicLinkProcessing, setIsMagicLinkProcessing] = useState(false);
+  const [otpCode, setOtpCode] = useState("");
+
+  // Standard form state
   const [email, setEmail] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -34,30 +58,156 @@ export default function SignUpWithInvite() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
-  function handleInviteValidated(invitation: InvitationData) {
-    setInviteValidated(true);
-    setInvitationData(invitation);
-    // Pre-fill email if it came from an email invite
-    if (invitation.prefilled_email) {
-      setEmail(invitation.prefilled_email);
+  // =====================================================
+  // 1. Check registration mode + detect magic link arrival
+  // =====================================================
+  useEffect(() => {
+    async function init() {
+      // Check if this is a magic link arrival
+      const inviteToken = searchParams.get("invite");
+      const emailParam = searchParams.get("email");
+      const isMagic = searchParams.get("magic") === "1";
+
+      if (isMagic && inviteToken && emailParam) {
+        // Magic link flow: auto-validate and show OTP verification
+        setMagicLinkEmail(emailParam);
+        setStep("magic_link");
+        setRegMode("invite_only");
+
+        // Validate the invite token in background
+        try {
+          const { data } = await supabase.functions.invoke("validate-invite", {
+            body: { token: inviteToken },
+          });
+
+          if (data?.valid) {
+            setInvitationData({
+              invitation_id: data.invitation_id,
+              inviter_name: data.inviter_name,
+              invite_type: data.invite_type,
+              prefilled_email: data.prefilled_email,
+              expires_at: data.expires_at,
+              token: inviteToken,
+            });
+          }
+        } catch {
+          // Non-blocking â we still show the OTP form
+        }
+        return;
+      }
+
+      // Check feature flag for registration mode
+      try {
+        const { data } = await supabase.rpc("check_registration_mode");
+
+        if (data?.invite_only) {
+          setRegMode("invite_only");
+          // If there's an invite token in URL, auto-validate via InviteGate
+          if (inviteToken) {
+            setStep("gate");
+          } else {
+            setStep("gate");
+          }
+        } else {
+          setRegMode("public");
+          setStep("form");
+        }
+      } catch {
+        // Default to invite-only if we can't check
+        setRegMode("invite_only");
+        setStep("gate");
+      }
+    }
+
+    init();
+  }, [searchParams]);
+
+  // =====================================================
+  // 2. Magic Link: Verify OTP and complete registration
+  // =====================================================
+  async function handleMagicLinkVerify(e: React.FormEvent) {
+    e.preventDefault();
+    setIsMagicLinkProcessing(true);
+    setFormError(null);
+
+    try {
+      // Verify the OTP code sent to the invited email
+      const { data: authData, error: authError } =
+        await supabase.auth.verifyOtp({
+          email: magicLinkEmail,
+          token: otpCode,
+          type: "email",
+        });
+
+      if (authError) {
+        setFormError(
+          authError.message.includes("expired")
+            ? "This code has expired. Please ask for a new invitation."
+            : authError.message
+        );
+        return;
+      }
+
+      if (!authData.user) {
+        setFormError("Verification failed. Please try again.");
+        return;
+      }
+
+      // Accept the invite to link referral tree
+      if (invitationData?.token) {
+        try {
+          await supabase.functions.invoke("accept-invite", {
+            body: { token: invitationData.token },
+          });
+        } catch {
+          // Non-blocking
+          console.error("Accept invite failed after magic link signup");
+        }
+      }
+
+      setStep("magic_complete");
+
+      toast.success("Welcome to iCareerOS!", {
+        description: invitationData?.inviter_name
+          ? `Invited by ${invitationData.inviter_name}`
+          : "Your account is ready.",
+      });
+
+      // Redirect to dashboard after short delay
+      setTimeout(() => navigate("/dashboard"), 1500);
+    } catch {
+      setFormError("Something went wrong. Please try again.");
+    } finally {
+      setIsMagicLinkProcessing(false);
     }
   }
 
+  // =====================================================
+  // 3. InviteGate validated callback
+  // =====================================================
+  function handleInviteValidated(invitation: InvitationData) {
+    setInvitationData(invitation);
+    if (invitation.prefilled_email) {
+      setEmail(invitation.prefilled_email);
+    }
+    setStep("form");
+  }
+
+  // =====================================================
+  // 4. Standard signup (email + password)
+  // =====================================================
   async function handleSignUp(e: React.FormEvent) {
     e.preventDefault();
     setFormError(null);
 
-    // Validate
     if (!email || !password || !confirmPassword) {
       setFormError("Please fill in all required fields.");
       return;
     }
-
     if (password !== confirmPassword) {
       setFormError("Passwords don't match.");
       return;
     }
-
     if (password.length < 8) {
       setFormError("Password must be at least 8 characters.");
       return;
@@ -66,7 +216,6 @@ export default function SignUpWithInvite() {
     setIsSubmitting(true);
 
     try {
-      // Step 1: Create the user via Supabase Auth
       const { data: authData, error: authError } = await supabase.auth.signUp({
         email,
         password,
@@ -79,7 +228,9 @@ export default function SignUpWithInvite() {
 
       if (authError) {
         if (authError.message.includes("already registered")) {
-          setFormError("This email is already registered. Try logging in instead.");
+          setFormError(
+            "This email is already registered. Try logging in instead."
+          );
         } else {
           setFormError(authError.message);
         }
@@ -91,27 +242,27 @@ export default function SignUpWithInvite() {
         return;
       }
 
-      // Step 2: Accept the invite (links user to referral tree)
-      const { data: session } = await supabase.auth.getSession();
-      if (session?.session?.access_token) {
-        const { error: acceptError } = await supabase.functions.invoke(
-          "accept-invite",
-          {
-            body: {
-              token: invitationData?.token || undefined,
-              invite_code: invitationData?.invite_code || undefined,
-            },
+      // Accept invite if we have one
+      if (invitationData) {
+        const { data: session } = await supabase.auth.getSession();
+        if (session?.session?.access_token) {
+          try {
+            await supabase.functions.invoke("accept-invite", {
+              body: {
+                token: invitationData.token || undefined,
+                invite_code: invitationData.invite_code || undefined,
+              },
+            });
+          } catch {
+            console.error("Accept invite error â non-blocking");
           }
-        );
-
-        if (acceptError) {
-          console.error("Accept invite error:", acceptError);
-          // Don't block signup â the user is created, invite acceptance is secondary
         }
       }
 
       toast.success("Welcome to iCareerOS!", {
-        description: `Invited by ${invitationData?.inviter_name || "a friend"}`,
+        description: invitationData?.inviter_name
+          ? `Invited by ${invitationData.inviter_name}`
+          : "Your account has been created.",
       });
 
       navigate("/dashboard");
@@ -122,8 +273,124 @@ export default function SignUpWithInvite() {
     }
   }
 
-  // Show invite gate if not yet validated
-  if (!inviteValidated) {
+  // =====================================================
+  // RENDER: Loading state
+  // =====================================================
+  if (regMode === "loading") {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <Loader2 className="h-8 w-8 animate-spin text-[#00B8A9]" />
+      </div>
+    );
+  }
+
+  // =====================================================
+  // RENDER: Magic link completion screen
+  // =====================================================
+  if (step === "magic_complete") {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background p-4">
+        <Card className="w-full max-w-md border-border/50 shadow-lg">
+          <CardContent className="pt-8 pb-8 text-center">
+            <CheckCircle2 className="h-16 w-16 text-green-500 mx-auto mb-4" />
+            <h2 className="text-2xl font-bold mb-2">You're In!</h2>
+            <p className="text-muted-foreground">
+              Welcome to iCareerOS. Redirecting to your dashboard...
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // =====================================================
+  // RENDER: Magic link OTP verification
+  // =====================================================
+  if (step === "magic_link") {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background p-4">
+        <div className="w-full max-w-md">
+          <Card className="border-border/50 shadow-lg">
+            <CardHeader className="text-center pb-4">
+              <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-[#00B8A9]/10">
+                <Mail className="h-7 w-7 text-[#00B8A9]" />
+              </div>
+              {invitationData && (
+                <div className="flex justify-center mb-3">
+                  <InvitedByBadge
+                    inviterName={invitationData.inviter_name || "a friend"}
+                  />
+                </div>
+              )}
+              <CardTitle className="text-2xl font-bold">
+                Complete Your Registration
+              </CardTitle>
+              <CardDescription className="text-base mt-2">
+                We sent a verification code to{" "}
+                <strong>{magicLinkEmail}</strong>. Enter it below to activate
+                your account.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent>
+              <form onSubmit={handleMagicLinkVerify} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="otp">Verification Code</Label>
+                  <Input
+                    id="otp"
+                    type="text"
+                    placeholder="Enter 6-digit code from your email"
+                    value={otpCode}
+                    onChange={(e) => {
+                      setOtpCode(e.target.value.replace(/\D/g, "").slice(0, 6));
+                      setFormError(null);
+                    }}
+                    disabled={isMagicLinkProcessing}
+                    className="text-center text-2xl tracking-[0.5em] font-mono h-14"
+                    autoFocus
+                    maxLength={6}
+                  />
+                </div>
+
+                {formError && (
+                  <div className="p-3 rounded-lg bg-destructive/10 text-destructive text-sm">
+                    {formError}
+                  </div>
+                )}
+
+                <Button
+                  type="submit"
+                  className="w-full h-11 bg-[#00B8A9] hover:bg-[#00A89A] text-white"
+                  disabled={isMagicLinkProcessing || otpCode.length < 6}
+                >
+                  {isMagicLinkProcessing ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Verifying...
+                    </>
+                  ) : (
+                    "Complete Registration"
+                  )}
+                </Button>
+              </form>
+
+              <div className="mt-6 pt-4 border-t text-center">
+                <p className="text-sm text-muted-foreground">
+                  Didn't receive the code? Check your spam folder or ask the
+                  person who invited you to send a new invitation.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  // =====================================================
+  // RENDER: Invite gate (invite-only mode, no invite yet)
+  // =====================================================
+  if (step === "gate" && regMode === "invite_only") {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background p-4">
         <InviteGate onValidated={handleInviteValidated} />
@@ -131,17 +398,22 @@ export default function SignUpWithInvite() {
     );
   }
 
-  // Show signup form after invite is validated
+  // =====================================================
+  // RENDER: Standard signup form
+  // (shown after invite validation OR in public mode)
+  // =====================================================
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-md">
         <Card className="border-border/50 shadow-lg">
           <CardHeader className="text-center pb-4">
-            <div className="flex justify-center mb-3">
-              <InvitedByBadge
-                inviterName={invitationData?.inviter_name || "a friend"}
-              />
-            </div>
+            {invitationData && (
+              <div className="flex justify-center mb-3">
+                <InvitedByBadge
+                  inviterName={invitationData.inviter_name || "a friend"}
+                />
+              </div>
+            )}
             <CardTitle className="text-2xl font-bold">
               Create Your Account
             </CardTitle>
@@ -151,17 +423,21 @@ export default function SignUpWithInvite() {
           </CardHeader>
 
           <CardContent>
-            {/* OAuth buttons (same as existing signup) */}
+            {/* OAuth buttons */}
             <div className="space-y-2 mb-4">
               <Button
                 type="button"
                 variant="outline"
                 className="w-full h-11"
                 onClick={async () => {
+                  const inviteParam =
+                    invitationData?.token ||
+                    invitationData?.invite_code ||
+                    "";
                   await supabase.auth.signInWithOAuth({
                     provider: "google",
                     options: {
-                      redirectTo: `${window.location.origin}/auth/callback?invite=${invitationData?.token || invitationData?.invite_code || ""}`,
+                      redirectTo: `${window.location.origin}/auth/callback${inviteParam ? `?invite=${inviteParam}` : ""}`,
                     },
                   });
                 }}
@@ -192,15 +468,23 @@ export default function SignUpWithInvite() {
                 variant="outline"
                 className="w-full h-11"
                 onClick={async () => {
+                  const inviteParam =
+                    invitationData?.token ||
+                    invitationData?.invite_code ||
+                    "";
                   await supabase.auth.signInWithOAuth({
                     provider: "apple",
                     options: {
-                      redirectTo: `${window.location.origin}/auth/callback?invite=${invitationData?.token || invitationData?.invite_code || ""}`,
+                      redirectTo: `${window.location.origin}/auth/callback${inviteParam ? `?invite=${inviteParam}` : ""}`,
                     },
                   });
                 }}
               >
-                <svg className="h-5 w-5 mr-2" viewBox="0 0 24 24" fill="currentColor">
+                <svg
+                  className="h-5 w-5 mr-2"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                >
                   <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
                 </svg>
                 Continue with Apple
@@ -224,8 +508,7 @@ export default function SignUpWithInvite() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   disabled={
-                    isSubmitting ||
-                    !!(invitationData?.prefilled_email)
+                    isSubmitting || !!invitationData?.prefilled_email
                   }
                   required
                 />

--- a/supabase/functions/send-invite/index.ts
+++ b/supabase/functions/send-invite/index.ts
@@ -1,6 +1,8 @@
-// supabase/functions/send-invite/index.ts
+// supabase/functions/send-invite/index.ts (v2)
 // POST /functions/v1/send-invite
-// Creates an invitation (email or code) and optionally sends via Resend.
+// Creates an invitation and sends a magic link for email invites.
+// The magic link uses Supabase Auth's magiclink flow so the invitee
+// registers with the exact email they were invited with â no password needed.
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
@@ -22,7 +24,7 @@ function generateToken(): string {
 
 function generateInviteCode(usernamePrefix: string): string {
   const prefix = usernamePrefix.toUpperCase().slice(0, 4).padEnd(4, "X");
-  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // no I/O/0/1 for readability
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
   let random = "";
   const bytes = new Uint8Array(4);
   crypto.getRandomValues(bytes);
@@ -42,7 +44,10 @@ serve(async (req: Request) => {
     if (!authHeader) {
       return new Response(
         JSON.stringify({ error: "Missing authorization header" }),
-        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        {
+          status: 401,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
       );
     }
 
@@ -51,15 +56,22 @@ serve(async (req: Request) => {
     const resendApiKey = Deno.env.get("RESEND_API_KEY");
 
     // Auth client to verify the caller
-    const supabaseAuth = createClient(supabaseUrl, Deno.env.get("SUPABASE_ANON_KEY")!, {
-      global: { headers: { Authorization: authHeader } },
-    });
-    const { data: { user }, error: authError } = await supabaseAuth.auth.getUser();
+    const supabaseAuth = createClient(
+      supabaseUrl,
+      Deno.env.get("SUPABASE_ANON_KEY")!,
+      {
+        global: { headers: { Authorization: authHeader } },
+      }
+    );
+    const {
+      data: { user },
+      error: authError,
+    } = await supabaseAuth.auth.getUser();
     if (authError || !user) {
-      return new Response(
-        JSON.stringify({ error: "Unauthorized" }),
-        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
-      );
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
     // Service client for DB operations
@@ -70,15 +82,23 @@ serve(async (req: Request) => {
 
     if (!type || !["email", "code"].includes(type)) {
       return new Response(
-        JSON.stringify({ error: "Invalid invite type. Must be 'email' or 'code'." }),
-        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        JSON.stringify({
+          error: "Invalid invite type. Must be 'email' or 'code'.",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
       );
     }
 
     if (type === "email" && !email) {
       return new Response(
         JSON.stringify({ error: "Email is required for email-type invites." }),
-        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
       );
     }
 
@@ -86,7 +106,10 @@ serve(async (req: Request) => {
     if (type === "email" && email === user.email) {
       return new Response(
         JSON.stringify({ error: "You cannot invite yourself." }),
-        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
       );
     }
 
@@ -100,8 +123,13 @@ serve(async (req: Request) => {
 
       if (existingUser) {
         return new Response(
-          JSON.stringify({ error: "This email is already registered on iCareerOS." }),
-          { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+          JSON.stringify({
+            error: "This email is already registered on iCareerOS.",
+          }),
+          {
+            status: 400,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          }
         );
       }
 
@@ -115,21 +143,31 @@ serve(async (req: Request) => {
 
       if (pendingInvite) {
         return new Response(
-          JSON.stringify({ error: "This email already has a pending invite." }),
-          { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+          JSON.stringify({
+            error: "This email already has a pending invite.",
+          }),
+          {
+            status: 400,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          }
         );
       }
     }
 
-    // Check daily limit (race-condition safe via advisory lock in the RPC)
-    const { data: limitCheck, error: limitError } = await supabase
-      .rpc("check_and_increment_invite_limit", { p_inviter_id: user.id });
+    // Check daily limit (race-condition safe via advisory lock)
+    const { data: limitCheck, error: limitError } = await supabase.rpc(
+      "check_and_increment_invite_limit",
+      { p_inviter_id: user.id }
+    );
 
     if (limitError) {
       console.error("Limit check error:", limitError);
       return new Response(
         JSON.stringify({ error: "Failed to check invite limit." }),
-        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
       );
     }
 
@@ -140,11 +178,14 @@ serve(async (req: Request) => {
           invites_remaining_today: 0,
           resets_at: limitCheck.resets_at,
         }),
-        { status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        {
+          status: 429,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
       );
     }
 
-    // Get inviter's username for code generation
+    // Get inviter's profile for code generation and email personalization
     const { data: profile } = await supabase
       .from("profiles")
       .select("username, full_name")
@@ -153,7 +194,8 @@ serve(async (req: Request) => {
 
     const usernamePrefix = profile?.username || profile?.full_name || "USER";
     const token = generateToken();
-    const inviteCode = type === "code" ? generateInviteCode(usernamePrefix) : null;
+    const inviteCode =
+      type === "code" ? generateInviteCode(usernamePrefix) : null;
 
     // Insert invitation
     const { data: invitation, error: insertError } = await supabase
@@ -165,7 +207,9 @@ serve(async (req: Request) => {
         token,
         invite_code: inviteCode,
         status: "pending",
-        expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        expires_at: new Date(
+          Date.now() + 7 * 24 * 60 * 60 * 1000
+        ).toISOString(),
       })
       .select()
       .single();
@@ -174,16 +218,50 @@ serve(async (req: Request) => {
       console.error("Insert error:", insertError);
       return new Response(
         JSON.stringify({ error: "Failed to create invitation." }),
-        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
       );
     }
 
-    // Send email via Resend if email-type invite
+    // ===================================================================
+    // MAGIC LINK FLOW: For email invites, send a magic link via Resend.
+    // The link lands on /auth/signup?invite=<token>&magic=1
+    // which auto-validates the invite and completes registration.
+    // ===================================================================
     if (type === "email" && resendApiKey) {
-      const inviterName = profile?.full_name || profile?.username || "Someone";
-      const signupUrl = `https://icareeros.com/auth/signup?invite=${token}`;
+      const inviterName =
+        profile?.full_name || profile?.username || "Someone";
+
+      // Build the magic link URL:
+      // The token is the invite token â the signup page will validate it,
+      // pre-fill the email, and use Supabase OTP to authenticate.
+      const siteUrl = Deno.env.get("SITE_URL") || "https://icareeros.com";
+      const magicLinkUrl = `${siteUrl}/auth/signup?invite=${token}&email=${encodeURIComponent(email!)}&magic=1`;
 
       try {
+        // Step 1: Send a Supabase OTP to the email (creates user if needed)
+        // This generates a one-time code Supabase will validate on login
+        const { error: otpError } = await supabase.auth.signInWithOtp({
+          email: email!,
+          options: {
+            shouldCreateUser: true,
+            data: {
+              invited_via_token: token,
+              invited_by: user.id,
+            },
+            emailRedirectTo: `${siteUrl}/auth/callback?invite=${token}`,
+          },
+        });
+
+        if (otpError) {
+          console.error("OTP generation error:", otpError);
+          // Fall back to branded email with manual link
+        }
+
+        // Step 2: Send branded invitation email via Resend
+        // (This gives us full branding control vs. the default Supabase email)
         const emailResponse = await fetch("https://api.resend.com/emails", {
           method: "POST",
           headers: {
@@ -197,30 +275,46 @@ serve(async (req: Request) => {
             html: `
               <div style="font-family: Arial, sans-serif; max-width: 560px; margin: 0 auto; padding: 40px 20px;">
                 <div style="text-align: center; margin-bottom: 32px;">
-                  <h1 style="color: #00B8A9; font-size: 24px; margin: 0;">iCareerOS</h1>
+                  <h1 style="color: #00B8A9; font-size: 28px; margin: 0;">iCareerOS</h1>
+                  <p style="color: #888; font-size: 14px; margin-top: 4px;">AI-Powered Career Operating System</p>
                 </div>
-                <p style="font-size: 16px; color: #333;">Hi there,</p>
-                <p style="font-size: 16px; color: #333;">
+
+                <p style="font-size: 16px; color: #333; line-height: 1.6;">
                   <strong>${inviterName}</strong> thinks you'd be a great fit for
-                  <strong>iCareerOS</strong> &mdash; the AI-powered Career Operating System.
+                  <strong>iCareerOS</strong> and has invited you to join the platform.
                 </p>
-                <p style="font-size: 16px; color: #333;">
-                  iCareerOS is currently invite-only. Click below to claim your spot:
+
+                <p style="font-size: 16px; color: #333; line-height: 1.6;">
+                  Click the button below to complete your registration. No password needed &mdash;
+                  you'll be signed in automatically with this email address.
                 </p>
-                <div style="text-align: center; margin: 32px 0;">
-                  <a href="${signupUrl}"
-                     style="background-color: #00B8A9; color: white; padding: 14px 32px;
+
+                <div style="text-align: center; margin: 36px 0;">
+                  <a href="${magicLinkUrl}"
+                     style="background-color: #00B8A9; color: white; padding: 16px 40px;
                             border-radius: 8px; text-decoration: none; font-size: 16px;
                             font-weight: 600; display: inline-block;">
-                    Join iCareerOS
+                    Complete Registration
                   </a>
                 </div>
-                <p style="font-size: 14px; color: #888;">
-                  This invitation expires in 7 days.
+
+                <div style="background: #f8f9fa; border-radius: 8px; padding: 16px; margin: 24px 0;">
+                  <p style="font-size: 13px; color: #666; margin: 0;">
+                    <strong>Your email:</strong> ${email}<br/>
+                    <strong>Invited by:</strong> ${inviterName}<br/>
+                    <strong>Expires:</strong> 7 days from now
+                  </p>
+                </div>
+
+                <p style="font-size: 13px; color: #999; line-height: 1.5;">
+                  If the button doesn't work, copy and paste this link into your browser:<br/>
+                  <a href="${magicLinkUrl}" style="color: #00B8A9; word-break: break-all;">${magicLinkUrl}</a>
                 </p>
+
                 <hr style="border: none; border-top: 1px solid #eee; margin: 32px 0;" />
                 <p style="font-size: 12px; color: #aaa; text-align: center;">
-                  &mdash; The iCareerOS Team
+                  You received this because ${inviterName} invited you to iCareerOS.<br/>
+                  If you didn't expect this, you can safely ignore this email.
                 </p>
               </div>
             `,
@@ -244,13 +338,19 @@ serve(async (req: Request) => {
         invites_remaining_today: limitCheck.remaining,
         expires_at: invitation.expires_at,
       }),
-      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      {
+        status: 200,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
     );
   } catch (err) {
     console.error("Unexpected error:", err);
     return new Response(
       JSON.stringify({ error: "Internal server error" }),
-      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
     );
   }
 });

--- a/supabase/migrations/20260413000000_platform_settings.sql
+++ b/supabase/migrations/20260413000000_platform_settings.sql
@@ -1,0 +1,119 @@
+-- ============================================================
+-- iCareerOS: Platform Settings Enhancement
+-- Migration: 20260413000000_platform_settings.sql
+-- Description: Adds updated_at tracking to feature_flags,
+--   adds admin update policy, ensures the toggle works from
+--   the PlatformSettings admin page.
+-- ============================================================
+
+-- ===================
+-- 1. ADD updated_at TO feature_flags (if not exists)
+-- ===================
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'feature_flags'
+      AND column_name = 'updated_at'
+  ) THEN
+    ALTER TABLE public.feature_flags
+      ADD COLUMN updated_at TIMESTAMPTZ DEFAULT now();
+  END IF;
+END $$;
+
+-- ===================
+-- 2. RLS: Allow admins to update feature flags
+-- ===================
+ALTER TABLE public.feature_flags ENABLE ROW LEVEL SECURITY;
+
+-- Admins can read all feature flags
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'feature_flags'
+      AND policyname = 'Admins can view feature flags'
+  ) THEN
+    CREATE POLICY "Admins can view feature flags"
+      ON public.feature_flags FOR SELECT
+      USING (
+        (SELECT raw_user_meta_data->>'role' FROM auth.users WHERE id = auth.uid()) = 'admin'
+      );
+  END IF;
+END $$;
+
+-- Admins can update feature flags
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'feature_flags'
+      AND policyname = 'Admins can update feature flags'
+  ) THEN
+    CREATE POLICY "Admins can update feature flags"
+      ON public.feature_flags FOR UPDATE
+      USING (
+        (SELECT raw_user_meta_data->>'role' FROM auth.users WHERE id = auth.uid()) = 'admin'
+      );
+  END IF;
+END $$;
+
+-- Authenticated users can read feature flags (needed for signup gate check)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'feature_flags'
+      AND policyname = 'Authenticated users can read feature flags'
+  ) THEN
+    CREATE POLICY "Authenticated users can read feature flags"
+      ON public.feature_flags FOR SELECT
+      USING (auth.role() = 'authenticated');
+  END IF;
+END $$;
+
+-- Anonymous users can read feature flags (needed for signup page to check mode)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'feature_flags'
+      AND policyname = 'Anon users can read feature flags'
+  ) THEN
+    CREATE POLICY "Anon users can read feature flags"
+      ON public.feature_flags FOR SELECT
+      USING (auth.role() = 'anon');
+  END IF;
+END $$;
+
+-- ===================
+-- 3. RPC: Check registration mode (for signup page)
+-- ===================
+CREATE OR REPLACE FUNCTION public.check_registration_mode()
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_invite_only BOOLEAN;
+BEGIN
+  SELECT enabled INTO v_invite_only
+  FROM public.feature_flags
+  WHERE key = 'invite_only_enrollment';
+
+  -- Default to invite-only if flag doesn't exist
+  IF v_invite_only IS NULL THEN
+    v_invite_only := true;
+  END IF;
+
+  RETURN json_build_object(
+    'invite_only', v_invite_only,
+    'mode', CASE WHEN v_invite_only THEN 'invite_only' ELSE 'public' END
+  );
+END;
+$$;
+
+-- Grant execute to anon so the signup page can check the mode
+GRANT EXECUTE ON FUNCTION public.check_registration_mode() TO anon;
+GRANT EXECUTE ON FUNCTION public.check_registration_mode() TO authenticated;


### PR DESCRIPTION
## Summary
- **ReferralProgram.tsx**: Replaces standalone /invites page; embeds in career profile with email invite (magic link) and shareable code tabs
- - **PlatformSettings.tsx**: Admin toggle between Invite-Only and Public Access mode
- - **SignUpWithInvite.tsx**: Updated for magic link OTP flow + registration mode check
- - **send-invite Edge Function**: Now sends Supabase OTP + branded Resend magic link emails
- - **invites.ts**: Added `checkRegistrationMode()` utility
## Database (already applied)
- Migration `20260413000000_platform_settings.sql` adds updated_at to feature_flags, RLS policies, and `check_registration_mode()` RPC
## Test plan
- [ ] Send an email invite → verify magic link email arrives
- [ ] - [ ] Click magic link → verify OTP entry and auto-registration
- [ ] - [ ] Generate invite code → share and verify code-based signup
- [ ] - [ ] Toggle Platform Settings to Public → verify signup without invite
- [ ] - [ ] Toggle back to Invite-Only → verify invite gate appears
- [ ] - [ ] Check daily limit (5/day) is enforced