### PR TITLE
fix: apply orbital logo and theme colors to landing, auth, and sidebar

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -34,8 +34,10 @@ export function AppSidebar() {
         <div className={`flex items-center gap-2 px-4 py-5 ${collapsed ? "justify-center" : ""}`}>
           <Logo size={28} />
           {!collapsed && (
-            <span className="font-display text-lg font-bold text-sidebar-foreground">iCareerOS</span>
-          )}
+              <span style={{ fontSize: '15px', fontWeight: 500, color: 'var(--text-primary)', letterSpacing: '-0.2px' }}>
+                                iCareer<span style={{ color: 'var(--brand)' }}>OS</span>
+                                              </span>
+                                                        )}
         </div>
 
         {/* Mode switcher */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,6 +14,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useAuthReady } from "@/hooks/useAuthReady";
 import { analyzeJobFit } from "@/lib/analysisEngine";
 import { AUTH_LOGIN, AUTH_SIGNUP } from "@/lib/routes";
+import { Logo } from '@/assets/Logo';
 /* ────────────────────── DATA ────────────────────── */
 
 const stats = [
@@ -183,13 +184,11 @@ export default function Index() {
           className="flex items-center gap-2 cursor-pointer"
           onClick={() => navigate("/")}
         >
-          <div className="w-8 h-8 gradient-teal rounded-lg flex items-center justify-center shadow-teal">
-            <Target className="w-4 h-4 text-white" />
-          </div>
-          <span className="font-display text-lg font-bold text-primary-foreground">
-            iCareerOS
-          </span>
-        </div>
+          <Logo size={28} />
+                    <span style={{ fontSize: '15px', fontWeight: 500, color: 'var(--text-primary)', letterSpacing: '-0.2px' }}>
+                                iCareer<span style={{ color: 'var(--brand)' }}>OS</span>
+                                          </span>
+                                                  </div>
 
         <nav className="flex items-center gap-1">
           {user ? (

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -20,6 +20,7 @@ import DashboardModeDialog from "@/components/DashboardModeDialog";
 import { login, loginWithGoogle, loginWithApple } from "@/services/user/auth";
 import { normalizeError } from "@/lib/normalizeError";
 import { supabase } from "@/integrations/supabase/client";
+import { Logo } from '@/assets/Logo';
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -136,11 +137,11 @@ export default function LoginPage() {
       <div className="w-full max-w-sm text-center space-y-8">
         {/* Branding */}
         <div className="flex flex-col items-center gap-3">
-          <div className="w-14 h-14 gradient-teal rounded-2xl flex items-center justify-center shadow-teal">
-            <Target className="w-7 h-7 text-white" />
-          </div>
-          <h1 className="font-display text-3xl font-bold text-primary">iCareerOS</h1>
-          <p className="text-muted-foreground text-sm">
+            <Logo size={48} />
+                        <h1 className="font-display text-3xl font-bold text-primary">
+                                      iCareer<span style={{ color: 'var(--brand)' }}>OS</span>
+                                                  </h1>
+                                                            <p className="text-muted-foreground text-sm">
             Sign in to save your analyses and track your progress
           </p>
         </div>
@@ -238,8 +239,8 @@ export default function LoginPage() {
 
           <Button
             type="submit"
-            className="w-full"
-            disabled={loading || !identifier.trim() || !password}
+              className="w-full gradient-teal text-white"
+                          disabled={loading || !identifier.trim() || !password}
           >
             {loadingEmail ? "Signing in\u2026" : "Sign in"}
           </Button>


### PR DESCRIPTION
## Summary
- Replace old Target icon logo with new `<Logo />` component in landing page navbar, auth/login page, and sidebar
- - Apply branded "iCareerOS" text styling with `var(--brand)` color on the "OS" portion
- - Update auth sign-in button from default gray to `gradient-teal text-white` brand colors
## Files changed
- `src/pages/Index.tsx` — Landing page navbar logo + branded text
- - `src/pages/auth/Login.tsx` — Auth page logo + sign-in button color
- - `src/components/AppSidebar.tsx` — Sidebar logo text styling