### PR TITLE
feat: replace gear logo with iCareerOS orbital SVG icon, update favicon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,14 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44 44">
-  <circle cx="22" cy="22" r="19" fill="none" stroke="#748FFC" stroke-width="0.8" stroke-dasharray="3 2.5" opacity="0.5"/>
-  <circle cx="22" cy="22" r="14" fill="none" stroke="#3B5BDB" stroke-width="2"/>
-  <circle cx="22" cy="22" r="8"  fill="none" stroke="#748FFC" stroke-width="1" stroke-dasharray="2.5 2" opacity="0.7"/>
-  <circle cx="22" cy="22" r="5"  fill="#3B5BDB"/>
-  <path d="M22 25 L22 19" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M19.5 21.5 L22 19 L24.5 21.5" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44 44" fill="none">
+  <ellipse cx="22" cy="22" rx="19" ry="19" stroke="#748FFC" stroke-width="0.8" stroke-dasharray="3 2.5" opacity="0.5"/>
+  <ellipse cx="22" cy="22" rx="14" ry="14" stroke="#3B5BDB" stroke-width="2.5"/>
+  <ellipse cx="22" cy="22" rx="8" ry="8" stroke="#748FFC" stroke-width="1" stroke-dasharray="2.5 2" opacity="0.7"/>
+  <circle cx="22" cy="22" r="5" fill="#3B5BDB"/>
+  <path d="M22 25 L22 19" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M19.5 21.5 L22 19 L24.5 21.5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
   <circle cx="22" cy="8"  r="2.5" fill="#3B5BDB"/>
   <circle cx="36" cy="22" r="2.5" fill="#3B5BDB"/>
-  <circle cx="22" cy="36" r="2"   fill="#748FFC" opacity="0.8"/>
-  <circle cx="8"  cy="22" r="2"   fill="#748FFC" opacity="0.8"/>
-  <circle cx="33" cy="11" r="1.5" fill="#4DABF7"/>
-  <circle cx="11" cy="33" r="1.2" fill="#4DABF7" opacity="0.7"/>
+  <circle cx="22" cy="36" r="2"   fill="#4DABF7" opacity="0.8"/>
+  <circle cx="8"  cy="22" r="2"   fill="#4DABF7" opacity="0.8"/>
 </svg>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, Shield } from "lucide-react";
-import { Logo } from "@/assets/Logo";
+import { ICareerOSLogo } from "@/components/ui/ICareerOSLogo";
 import { NavLink } from "@/components/NavLink";
 import { useLocation, useNavigate } from "react-router-dom";
 import {
@@ -31,13 +31,14 @@ export function AppSidebar() {
     <Sidebar collapsible="icon">
       <SidebarContent>
         {/* Logo */}
-        <div className={`flex items-center gap-2 px-4 py-5 ${collapsed ? "justify-center" : ""}`}>
-          <Logo size={28} />
+        <div className={`flex items-center gap-2 px-4 py-3 select-none ${collapsed ? "justify-center" : ""}`}>
+          <ICareerOSLogo size={24} />
           {!collapsed && (
-              <span style={{ fontSize: '15px', fontWeight: 500, color: 'var(--text-primary)', letterSpacing: '-0.2px' }}>
-                                iCareer<span style={{ color: 'var(--brand)' }}>OS</span>
-                                              </span>
-                                                        )}
+            <span className="text-sm font-medium">
+              <span className="text-primary">iCareer</span>
+              <span className="text-foreground">OS</span>
+            </span>
+          )}
         </div>
 
         {/* Mode switcher */}

--- a/src/components/ui/ICareerOSLogo.tsx
+++ b/src/components/ui/ICareerOSLogo.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+interface ICareerOSLogoProps {
+  size?: number;
+  className?: string;
+}
+
+export function ICareerOSLogo({ size = 32, className }: ICareerOSLogoProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 44 44"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-label="iCareerOS logo"
+    >
+      {/* Outermost dashed orbit ring */}
+      <ellipse
+        cx="22" cy="22" rx="19" ry="19"
+        stroke="#748FFC" strokeWidth="0.8"
+        strokeDasharray="3 2.5" opacity="0.5"
+      />
+      {/* Main solid orbit ring — uses CSS variable so it adapts to theme */}
+      <ellipse
+        cx="22" cy="22" rx="14" ry="14"
+        stroke="hsl(var(--primary))" strokeWidth="2"
+      />
+      {/* Inner dashed orbit */}
+      <ellipse
+        cx="22" cy="22" rx="8" ry="8"
+        stroke="#748FFC" strokeWidth="1"
+        strokeDasharray="2.5 2" opacity="0.7"
+      />
+      {/* Core circle */}
+      <circle cx="22" cy="22" r="5" fill="hsl(var(--primary))" />
+      {/* Upward arrow inside core */}
+      <path
+        d="M22 25 L22 19"
+        stroke="hsl(var(--primary-foreground))"
+        strokeWidth="1.5" strokeLinecap="round"
+      />
+      <path
+        d="M19.5 21.5 L22 19 L24.5 21.5"
+        stroke="hsl(var(--primary-foreground))"
+        strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+      />
+      {/* Orbit nodes — opportunities being surfaced */}
+      <circle cx="22" cy="8"  r="2.5" fill="hsl(var(--primary))" />
+      <circle cx="36" cy="22" r="2.5" fill="hsl(var(--primary))" />
+      <circle cx="22" cy="36" r="2"   fill="#4DABF7" opacity="0.8" />
+      <circle cx="8"  cy="22" r="2"   fill="#4DABF7" opacity="0.8" />
+      <circle cx="33" cy="11" r="1.5" fill="#4DABF7" />
+      <circle cx="11" cy="33" r="1.2" fill="#4DABF7" opacity="0.7" />
+    </svg>
+  );
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,7 +14,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useAuthReady } from "@/hooks/useAuthReady";
 import { analyzeJobFit } from "@/lib/analysisEngine";
 import { AUTH_LOGIN, AUTH_SIGNUP } from "@/lib/routes";
-import { Logo } from '@/assets/Logo';
+import { ICareerOSLogo } from '@/components/ui/ICareerOSLogo';
 /* ────────────────────── DATA ────────────────────── */
 
 const stats = [
@@ -184,10 +184,11 @@ export default function Index() {
           className="flex items-center gap-2 cursor-pointer"
           onClick={() => navigate("/")}
         >
-          <Logo size={28} />
-                    <span style={{ fontSize: '15px', fontWeight: 500, color: 'var(--text-primary)', letterSpacing: '-0.2px' }}>
-                                iCareer<span style={{ color: 'var(--brand)' }}>OS</span>
-                                          </span>
+          <ICareerOSLogo size={28} />
+          <span className="text-sm font-medium tracking-tight">
+            <span className="text-primary">iCareer</span>
+            <span className="text-foreground">OS</span>
+          </span>
                                                   </div>
 
         <nav className="flex items-center gap-1">

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -20,7 +20,7 @@ import DashboardModeDialog from "@/components/DashboardModeDialog";
 import { login, loginWithGoogle, loginWithApple } from "@/services/user/auth";
 import { normalizeError } from "@/lib/normalizeError";
 import { supabase } from "@/integrations/supabase/client";
-import { Logo } from '@/assets/Logo';
+import { ICareerOSLogo } from '@/components/ui/ICareerOSLogo';
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -136,12 +136,13 @@ export default function LoginPage() {
     <div className="min-h-screen bg-background flex items-center justify-center px-6">
       <div className="w-full max-w-sm text-center space-y-8">
         {/* Branding */}
-        <div className="flex flex-col items-center gap-3">
-            <Logo size={48} />
-                        <h1 className="font-display text-3xl font-bold text-primary">
-                                      iCareer<span style={{ color: 'var(--brand)' }}>OS</span>
-                                                  </h1>
-                                                            <p className="text-muted-foreground text-sm">
+        <div className="flex flex-col items-center gap-3 mb-6">
+          <ICareerOSLogo size={52} />
+          <span className="text-2xl font-semibold tracking-tight">
+            <span className="text-primary">iCareer</span>
+            <span className="text-foreground">OS</span>
+          </span>
+          <p className="text-muted-foreground text-sm">
             Sign in to save your analyses and track your progress
           </p>
         </div>


### PR DESCRIPTION
## Summary
- Created `ICareerOSLogo` component using `hsl(var(--primary))` for theme-aware colors
- Updated wordmark in header (28px), auth page (52px), and app sidebar (24px)
- `iCareer` now renders in `text-primary` (indigo in light, violet in dark); `OS` in `text-foreground`
- Favicon SVG updated with ellipse-based orbital rings

Depends on: #155
Closes #158

## Test plan
- [ ] Landing page header shows orbital logo (not gear)
- [ ] Auth/login page shows orbital logo at 52px
- [ ] Sidebar shows orbital logo at 24px when expanded
- [ ] Logo adapts (indigo light / violet dark) with theme
- [ ] Browser tab favicon shows orbital rings icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)