### PR TITLE
Rebrand: visual verification across all routes — light and dark mode

### DIFF
--- a/docs/rebrand-verification-checklist.md
+++ b/docs/rebrand-verification-checklist.md
@@ -1,0 +1,107 @@
+# iCareerOS Rebrand — Visual Verification Checklist
+
+Tracks Issue #168. Run after all PRs #155–#167 have been merged to `dev` and deployed to staging.
+
+---
+
+## Pre-flight
+
+- [ ] `dev` branch contains all 7 rebrand PRs (merged: #155, #157, #159, #161, #163, #165, #167)
+- [ ] Supabase migration `20260414000000_user_theme_preference.sql` applied to staging DB
+- [ ] Staging URL loaded in browser (Chrome recommended for DevTools console script)
+
+---
+
+## Landing Page (`/`)
+
+| Check | Light | Dark |
+|---|---|---|
+| Header surface: `bg-card/95` — not solid primary fill | ☐ | ☐ |
+| `ICareerOSLogo` renders orbital SVG with indigo ring | ☐ | ☐ |
+| Wordmark: `iCareer` primary, `OS` foreground | ☐ | ☐ |
+| Nav links: muted text, accent hover | ☐ | ☐ |
+| "Sign In" button: solid indigo | ☐ | ☐ |
+| "Try Demo" button: outlined, no fill | ☐ | ☐ |
+| Mobile sticky bar: `bg-card/95 border-border` | ☐ | ☐ |
+| Hero gradient: `from-indigo-900` (no navy) | ☐ | ☐ |
+| All scroll sections visible without blank gaps | ☐ | ☐ |
+
+---
+
+## Auth Pages
+
+| Check | Light | Dark |
+|---|---|---|
+| `/login` — 52px `ICareerOSLogo` visible | ☐ | ☐ |
+| `/login` — wordmark correct split | ☐ | ☐ |
+| `/signup` — same logo/wordmark | ☐ | ☐ |
+| Form focus rings: indigo, not teal | ☐ | ☐ |
+| Card background: `bg-card` (no hardcoded navy) | ☐ | ☐ |
+
+---
+
+## App Interior (post-login)
+
+| Check | Light | Dark |
+|---|---|---|
+| Sidebar — 24px `ICareerOSLogo` | ☐ | ☐ |
+| Sidebar wordmark correct | ☐ | ☐ |
+| Sidebar active item: `bg-accent` or `bg-primary/10` | ☐ | ☐ |
+| Dashboard cards: `bg-card border-border` | ☐ | ☐ |
+| Primary buttons: indigo, not teal | ☐ | ☐ |
+| Badge/pill tints: indigo accent | ☐ | ☐ |
+| Links: `text-primary` (indigo) | ☐ | ☐ |
+
+---
+
+## Settings (`/settings`)
+
+| Check | Light | Dark |
+|---|---|---|
+| Appearance section renders first | ☐ | ☐ |
+| Three theme cards shown: Light, Dark, Automatic | ☐ | ☐ |
+| Each card has mini-UI thumbnail | ☐ | ☐ |
+| Selected card: `border-primary bg-accent` + indigo dot | ☐ | ☐ |
+| Switching theme applies instantly (no reload) | ☐ | ☐ |
+| Preference persists after page refresh | ☐ | N/A |
+
+---
+
+## Token Spot-checks (DevTools)
+
+Open any route → DevTools → Elements → `<html>` → Computed tab. Verify:
+
+| Token | Light expected | Dark expected |
+|---|---|---|
+| `--primary` | `228 69% 55%` | `228 96% 72%` |
+| `--background` | `227 32% 97%` | `224 21% 8%` |
+| `--card` | `0 0% 100%` | `222 28% 12%` |
+| `--border` | `220 13% 91%` | `217 19% 27%` |
+
+---
+
+## Zero-Teal Console Script
+
+On each route, open DevTools → Console and run `docs/verify-zero-teal.js`.
+
+Expected output:
+
+```
+✅ Zero teal/navy computed styles found.
+```
+
+Routes to check:
+- [ ] `/`
+- [ ] `/login`
+- [ ] `/signup`
+- [ ] `/dashboard`
+- [ ] `/settings`
+- [ ] `/jobs` (or other interior route)
+
+---
+
+## Sign-off
+
+| Reviewer | Date | Notes |
+|---|---|---|
+| | | |

--- a/docs/verify-zero-teal.js
+++ b/docs/verify-zero-teal.js
@@ -1,0 +1,69 @@
+/**
+ * verify-zero-teal.js
+ *
+ * Run from the browser DevTools console on any iCareerOS route after the
+ * Design System & Brand Overhaul (PRs #155–#167) has been deployed.
+ *
+ * Reports any element still rendering a teal or navy computed color.
+ * Expected output on a clean build: ✅ Zero teal/navy computed styles found.
+ *
+ * Usage:
+ *   1. Open the page you want to check in Chrome/Firefox
+ *   2. Open DevTools (F12) → Console tab
+ *   3. Paste the entire IIFE below and press Enter
+ *   4. Repeat on each route: /, /login, /signup, /dashboard, /settings
+ */
+(function checkNoTeal() {
+  // Matches common teal/cyan computed RGB values
+  // teal: rgb(0,128,128)  tw-teal-500: rgb(20,184,166)  tw-teal-600: rgb(13,148,136)
+  const TEAL_RE = /rgb\(\s*(?:0\s*,\s*1(?:2[0-9]|[3-9]\d)\s*,\s*1(?:2[0-9]|[3-9]\d)|1[23]\s*,\s*1(?:4[0-9]|[5-8]\d)\s*,\s*1(?:3[0-9]|[4-6]\d))\s*\)/i;
+
+  // Matches navy dark palette: very low-red, low-green, mid-blue (navy-800/900 territory)
+  // e.g. rgb(10,25,80) through rgb(30,47,120) — roughly the old --navy-800/900 range
+  const NAVY_RE = /rgb\(\s*(?:[0-9]|[12]\d|30)\s*,\s*(?:[0-9]|[12]\d|3[0-9]|4[0-7])\s*,\s*(?:[5-9]\d|1(?:0[0-9]|1[0-9]|2[0-7]))\s*\)/i;
+
+  const PROPS = [
+    'color',
+    'background-color',
+    'border-color',
+    'border-top-color',
+    'border-right-color',
+    'border-bottom-color',
+    'border-left-color',
+    'outline-color',
+    'fill',
+    'stroke',
+    'box-shadow',
+    'text-decoration-color',
+  ];
+
+  const hits = [];
+
+  document.querySelectorAll('*').forEach(el => {
+    try {
+      const cs = window.getComputedStyle(el);
+      PROPS.forEach(prop => {
+        const v = cs.getPropertyValue(prop);
+        if (v && (TEAL_RE.test(v) || NAVY_RE.test(v))) {
+          hits.push({ element: el, prop, value: v });
+        }
+      });
+    } catch (_) {
+      // cross-origin iframes etc — skip silently
+    }
+  });
+
+  if (hits.length === 0) {
+    console.log(
+      '%c✅ Zero teal/navy computed styles found.',
+      'color: #22c55e; font-weight: bold; font-size: 14px;'
+    );
+  } else {
+    console.warn(`⚠️  ${hits.length} teal/navy hit(s) found — investigate below:`);
+    hits.forEach(({ element, prop, value }) => {
+      console.warn(`  ${prop}: ${value}`, element);
+    });
+  }
+
+  return hits;
+})();


### PR DESCRIPTION
## Summary

Visual QA tracking PR for the iCareerOS Design System & Brand Overhaul.

Merging this PR signals that the visual verification pass has been completed across all routes in both light and dark mode, after all preceding rebrand PRs have landed on `dev`.

**Prerequisite PRs (must be merged first):**
- #155 — `feature/rebrand-tokens` — Color token replacement
- #157 — `feature/fix-landing-animations` — Scroll animation fix
- #159 — `feature/rebrand-logo` — Orbital logo + favicon
- #161 — `feature/rebrand-color-sweep` — Full teal/navy color sweep
- #163 — `feature/rebrand-landing-bars` — Theme-aware header/mobile bar
- #165 — `feature/theme-switcher` — Canonical ThemeProvider
- #167 — `feature/settings-theme-ui` — ThemeSelector component

## What's in this PR

| File | Purpose |
|---|---|
| `docs/rebrand-verification-checklist.md` | Route-by-route QA table (light + dark) covering landing, auth, app interior, settings, and token spot-checks |
| `docs/verify-zero-teal.js` | DevTools IIFE — scans all computed styles and logs any surviving teal/navy RGB values |

## Test plan

- [ ] All PRs #155–#167 merged to `dev`
- [ ] Supabase migration `20260414000000_user_theme_preference.sql` applied
- [ ] Staging deployed from `dev`
- [ ] Work through every row in `docs/rebrand-verification-checklist.md`
- [ ] Run `docs/verify-zero-teal.js` from DevTools console on each route — expect `✅ Zero teal/navy computed styles found.`
- [ ] Theme switcher (Light / Dark / Automatic) verified in `/settings`

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
