### PR TITLE
feat: job search upgrades — DB view fix, freshness filter, pagination, search mode UI

### DIFF
--- a/src/pages/JobSearch.tsx
+++ b/src/pages/JobSearch.tsx
@@ -28,34 +28,27 @@ function parseSalaryNumber(salary: string): number | null {
   if (nums.length >= 2) return (nums[0] + nums[1]) / 2;
   return nums[0];
 }
-
 const MARKET_BENCHMARKS: Record<string, number> = {
   "entry": 65000, "junior": 75000, "mid": 105000, "senior": 140000, "lead": 165000,
   "staff": 185000, "principal": 210000, "director": 195000, "vp": 230000,
 };
-
 function estimateMarketRate(title: string): number {
   const lower = title.toLowerCase();
-  for (const [key, val] of Object.entries(MARKET_BENCHMARKS)) {
-    if (lower.includes(key)) return val;
-  }
+  for (const [key, val] of Object.entries(MARKET_BENCHMARKS)) { if (lower.includes(key)) return val; }
   if (lower.includes("engineer") || lower.includes("developer")) return 120000;
   if (lower.includes("manager")) return 130000;
   if (lower.includes("analyst")) return 90000;
   if (lower.includes("designer")) return 100000;
   return 100000;
 }
-
 function SalaryBadge({ salary, title }: { salary: string; title?: string }) {
   const parsed = parseSalaryNumber(salary);
   if (!parsed) return null;
-  const market = estimateMarketRate(title || "");
-  const diff = ((parsed - market) / market) * 100;
+  const diff = ((parsed - estimateMarketRate(title || "")) / estimateMarketRate(title || "")) * 100;
   if (diff >= 10) return <Badge variant="outline" className="text-[10px] bg-success/10 text-success border-success/30">↑ Above Market</Badge>;
   if (diff <= -10) return <Badge variant="outline" className="text-[10px] bg-destructive/10 text-destructive border-destructive/30">↓ Below Market</Badge>;
   return <Badge variant="outline" className="text-[10px] bg-accent/10 text-accent border-accent/30">≈ Market Rate</Badge>;
 }
-
 function getSmartTagUI(job: EnrichedJob, prob: number): { label: string; color: string; icon: any } {
   if (job.is_flagged) return { label: "Low Confidence", color: "text-destructive border-destructive/30", icon: AlertTriangle };
   if ((job.effortEstimate || 0) > 70 && prob < 40) return { label: "Low ROI", color: "text-destructive/70 border-destructive/20", icon: AlertTriangle };
@@ -67,18 +60,14 @@ function getSmartTagUI(job: EnrichedJob, prob: number): { label: string; color: 
   if (prob < 35) return { label: "Improve Resume First", color: "text-amber-600 border-amber-300 dark:text-amber-400", icon: Shield };
   return { label: "Worth Applying", color: "text-primary border-primary/30", icon: Target };
 }
-
 function getJobSaveKey(job: { url?: string; title: string; company: string }): string {
-  const urlPart = (job.url || "").trim().toLowerCase();
-  return `${urlPart}|${job.title.trim().toLowerCase()}|${job.company.trim().toLowerCase()}`;
+  return (job.url || "").trim().toLowerCase() + "|" + job.title.trim().toLowerCase() + "|" + job.company.trim().toLowerCase();
 }
-
 function getProbColor(prob: number) {
   if (prob >= 70) return "text-green-600 dark:text-green-400";
   if (prob >= 50) return "text-amber-600 dark:text-amber-400";
   return "text-destructive";
 }
-
 const JOB_TYPE_OPTIONS = ["remote", "hybrid", "in-office", "full-time", "part-time", "contract", "short-term"];
 const PAGE_SIZE = 50;
 
@@ -108,30 +97,21 @@ export default function JobSearchPage() {
   const [minFitScore, setMinFitScore] = useState(60);
   const [searchMode, setSearchMode] = useState<"quality" | "balanced" | "volume">("balanced");
   const [totalBeforeFilter, setTotalBeforeFilter] = useState(0);
+  const [daysOld, setDaysOld] = useState(0);
 
   useEffect(() => { loadProfile(); loadIgnoredAndSaved(); }, []);
 
-  // Auto-search once profile loads if the user has skills or titles saved.
-  // FIX: profileLoaded was never set to true, so this effect never fired.
   useEffect(() => {
     if (!profileLoaded) return;
-    if (skills.length > 0 || targetTitles.length > 0) {
-      handleSearch();
-    }
+    if (skills.length > 0 || targetTitles.length > 0) handleSearch();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profileLoaded]);
 
   const loadIgnoredAndSaved = async () => {
-    const [ignored, { data: { session } }] = await Promise.all([
-      getIgnoredJobs(),
-      supabase.auth.getSession(),
-    ]);
+    const [ignored, { data: { session } }] = await Promise.all([getIgnoredJobs(), supabase.auth.getSession()]);
     setIgnoredList(ignored);
     if (session) {
-      const { data } = await supabase
-        .from("job_applications")
-        .select("job_title, company, job_url")
-        .eq("user_id", session.user.id);
+      const { data } = await supabase.from("job_applications").select("job_title, company, job_url").eq("user_id", session.user.id);
       if (data) setSavedApps(data as any);
     }
   };
@@ -139,12 +119,9 @@ export default function JobSearchPage() {
   const loadProfile = async () => {
     try {
       const { data: { session } } = await supabase.auth.getSession();
-      // FIX: always mark profile as loaded even when unauthenticated
       if (!session) { setProfileLoaded(true); return; }
       const [{ data }, { data: appData }] = await Promise.all([
-        supabase.from("job_seeker_profiles")
-          .select("skills, preferred_job_types, location, career_level, target_job_titles, salary_min, salary_max, min_match_score, search_mode")
-          .eq("user_id", session.user.id).maybeSingle(),
+        supabase.from("job_seeker_profiles").select("skills, preferred_job_types, location, career_level, target_job_titles, salary_min, salary_max, min_match_score, search_mode").eq("user_id", session.user.id).maybeSingle(),
         supabase.from("job_applications").select("status, response_days").eq("user_id", session.user.id),
       ]);
       if (data) {
@@ -169,201 +146,140 @@ export default function JobSearchPage() {
     finally { setProfileLoaded(true); }
   };
 
-  const toggleJobType = (type: string) => {
-    setJobTypes(prev => prev.includes(type) ? prev.filter(t => t !== type) : [...prev, type]);
-  };
+  const toggleJobType = (type: string) => setJobTypes(prev => prev.includes(type) ? prev.filter(t => t !== type) : [...prev, type]);
 
-  // overrideFilters lets callers like "Browse all" bypass current state values.
-  // FIX: removed the hard validation that blocked searching without skills/query.
   const handleSearch = async (overrideFilters?: Partial<JobSearchFilters>) => {
-    setSearching(true);
-    setJobs([]);
-    setCitations([]);
-
+    setSearching(true); setJobs([]); setCitations([]);
     const filters: JobSearchFilters = {
       skills, jobTypes, location, query: customQuery, careerLevel,
       targetTitles, salaryMin, salaryMax, searchSource, minFitScore, showFlagged,
-      search_mode: searchMode,
+      search_mode: searchMode, days_old: daysOld,
       ...overrideFilters,
     };
-
-    let rawJobs: JobResult[] = [];
-    let cits: string[] = [];
+    let rawJobs: JobResult[] = [], cits: string[] = [];
     try {
       const result = await searchJobsService(filters);
-      rawJobs = result.jobs;
-      cits = result.citations;
-    } catch (e) {
-      console.error("[JobSearch] Search service error (recovering):", e);
-      toast.error("Search encountered an issue. Showing partial results.");
-    }
+      rawJobs = result.jobs; cits = result.citations;
+    } catch (e) { console.error("[JobSearch] error:", e); toast.error("Search encountered an issue."); }
 
-    let filtered = rawJobs
-      .filter(job => !isJobIgnored(job, ignoredList))
-      .filter(job => !isJobAlreadySaved(job, savedApps));
-
+    let filtered = rawJobs.filter(job => !isJobIgnored(job, ignoredList)).filter(job => !isJobAlreadySaved(job, savedApps));
     let enriched: EnrichedJob[];
     try {
       enriched = scoreJobs({ jobs: filtered, skills, historicalOutcomes, salaryMin, salaryMax, remotePreferred: jobTypes.includes("remote") });
     } catch (e) {
-      console.error("[JobSearch] Matching service error (degrading gracefully):", e);
-      enriched = filtered.map(job => ({
-        ...job, flags: [], trustScore: 50, trustLevel: "caution" as const,
-        strategy: "apply_now" as const, responseProbability: 50,
-        decisionScore: job.quality_score || 50, effortEstimate: 50, smartTag: "Worth Applying",
-      }));
+      enriched = filtered.map(job => ({ ...job, flags: [], trustScore: 50, trustLevel: "caution" as const, strategy: "apply_now" as const, responseProbability: 50, decisionScore: job.quality_score || 50, effortEstimate: 50, smartTag: "Worth Applying" }));
     }
-
     if (sortBy === "decision") enriched.sort((a, b) => (b.decisionScore || 0) - (a.decisionScore || 0));
     else if (sortBy === "probability") enriched.sort((a, b) => (b.responseProbability || 0) - (a.responseProbability || 0));
-    else if (sortBy === "newest") {
-      enriched.sort((a, b) => {
-        if (!a.first_seen_at && !b.first_seen_at) return 0;
-        if (!a.first_seen_at) return 1;
-        if (!b.first_seen_at) return -1;
-        return new Date(b.first_seen_at).getTime() - new Date(a.first_seen_at).getTime();
-      });
-    }
-
+    else if (sortBy === "newest") enriched.sort((a, b) => { if (!a.first_seen_at && !b.first_seen_at) return 0; if (!a.first_seen_at) return 1; if (!b.first_seen_at) return -1; return new Date(b.first_seen_at).getTime() - new Date(a.first_seen_at).getTime(); });
     if (!showFlagged) enriched = enriched.filter(j => !j.is_flagged);
     const effectiveMinFit = overrideFilters?.minFitScore ?? minFitScore;
     const beforeFilterCount = enriched.length;
     enriched = enriched.filter(j => (j.decisionScore || 0) >= effectiveMinFit);
-    setTotalBeforeFilter(beforeFilterCount);
-    setJobs(enriched);
-    setCitations(cits);
-    setVisibleCount(PAGE_SIZE);
-
-    if (!enriched.length && beforeFilterCount > 0) {
-      toast.info(`${beforeFilterCount} jobs found but hidden by your ${effectiveMinFit}% fit score filter. Try lowering it.`);
-    } else if (!enriched.length && rawJobs.length > 0) {
-      toast.info("Jobs found but all filtered out. Try lowering minimum fit score.");
-    } else if (!enriched.length) {
-      toast.info("No jobs found. Try adjusting your criteria.");
-    }
+    setTotalBeforeFilter(beforeFilterCount); setJobs(enriched); setCitations(cits); setVisibleCount(PAGE_SIZE);
+    if (!enriched.length && beforeFilterCount > 0) toast.info(beforeFilterCount + " jobs found but hidden by your " + effectiveMinFit + "% fit score filter.");
+    else if (!enriched.length && rawJobs.length > 0) toast.info("Jobs found but all filtered out.");
+    else if (!enriched.length) toast.info("No jobs found. Try adjusting your criteria.");
     setSearching(false);
   };
 
   const handleAnalyzeFit = (job: EnrichedJob) => {
-    const jobDesc = `${job.title} at ${job.company}\nLocation: ${job.location}\nType: ${job.type}${job.salary ? `\nSalary: ${job.salary}` : ""}\n\n${job.description}`;
+    const jobDesc = job.title + " at " + job.company + "\nLocation: " + job.location + "\nType: " + job.type + (job.salary ? "\nSalary: " + job.salary : "") + "\n\n" + job.description;
     navigate("/job-seeker", { state: { prefillJob: jobDesc, prefillJobLink: job.url || "", fromSearch: true } });
   };
 
   const handleSaveJob = async (job: EnrichedJob) => {
     const saveKey = getJobSaveKey(job);
     if (savingJobKeys[saveKey]) return;
-    setSavingJobKeys((prev) => ({ ...prev, [saveKey]: true }));
+    setSavingJobKeys(prev => ({ ...prev, [saveKey]: true }));
     try {
-      const result = await saveJobToApplications({
-        title: job.title, company: job.company, url: job.url,
-        description: job.description, location: job.location, type: job.type,
-      });
+      const result = await saveJobToApplications({ title: job.title, company: job.company, url: job.url, description: job.description, location: job.location, type: job.type });
       if (!result.ok) { toast.error(result.error || "Failed to save job"); return; }
       if (result.alreadySaved) { toast.info("Job already saved"); return; }
       toast.success("Job saved to Applications");
-    } finally {
-      setSavingJobKeys((prev) => ({ ...prev, [saveKey]: false }));
-    }
+    } finally { setSavingJobKeys(prev => ({ ...prev, [saveKey]: false })); }
   };
 
   return (
     <div className="bg-background">
       <div className="max-w-5xl mx-auto px-6 py-10">
         <div className="text-center mb-10">
-          <h1 className="font-display text-4xl font-bold text-primary mb-3">
-            Jobs that <span className="text-gradient-indigo">get you interviews</span>
-          </h1>
-          <p className="text-muted-foreground text-lg max-w-xl mx-auto">
-            AI finds the best opportunities and shows your interview probability for each one.
-          </p>
+          <h1 className="font-display text-4xl font-bold text-primary mb-3">Jobs that <span className="text-gradient-indigo">get you interviews</span></h1>
+          <p className="text-muted-foreground text-lg max-w-xl mx-auto">AI finds the best opportunities and shows your interview probability for each one.</p>
         </div>
-
         <Card className="p-6 mb-8">
           <div className="space-y-4">
             <div>
               <label className="text-sm font-semibold text-foreground mb-2 block">Search Source</label>
               <div className="flex gap-2">
                 {(["all", "database", "ai"] as const).map(src => (
-                  <Badge key={src} variant={searchSource === src ? "default" : "outline"}
-                    className={`cursor-pointer capitalize ${searchSource === src ? "bg-primary text-primary-foreground" : "hover:bg-accent/10"}`}
-                    onClick={() => setSearchSource(src)}>
-                    {src === "all" ? <><Database className="w-3 h-3 mr-1" /> All Sources</>
-                      : src === "database" ? <><Database className="w-3 h-3 mr-1" /> Job Database</>
-                      : <><Search className="w-3 h-3 mr-1" /> AI Search</>}
+                  <Badge key={src} variant={searchSource === src ? "default" : "outline"} className={"cursor-pointer capitalize " + (searchSource === src ? "bg-primary text-primary-foreground" : "hover:bg-accent/10")} onClick={() => setSearchSource(src)}>
+                    {src === "all" ? <><Database className="w-3 h-3 mr-1" />All Sources</> : src === "database" ? <><Database className="w-3 h-3 mr-1" />Job Database</> : <><Search className="w-3 h-3 mr-1" />AI Search</>}
                   </Badge>
                 ))}
               </div>
             </div>
-
             <div>
               <label className="text-sm font-semibold text-foreground mb-2 block">Target Job Titles</label>
               <div className="flex gap-2 mb-2">
-                <Input value={titleInput} onChange={e => setTitleInput(e.target.value)} placeholder="e.g. Software Engineer"
-                  onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); const t = titleInput.trim(); if (t && !targetTitles.includes(t)) { setTargetTitles([...targetTitles, t]); setTitleInput(""); } } }} />
-                <Button variant="outline" size="sm" onClick={() => { const t = titleInput.trim(); if (t && !targetTitles.includes(t)) { setTargetTitles([...targetTitles, t]); setTitleInput(""); } }}>
-                  <Plus className="w-4 h-4" />
-                </Button>
+                <Input value={titleInput} onChange={e => setTitleInput(e.target.value)} placeholder="e.g. Software Engineer" onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); const t = titleInput.trim(); if (t && !targetTitles.includes(t)) { setTargetTitles([...targetTitles, t]); setTitleInput(""); } } }} />
+                <Button variant="outline" size="sm" onClick={() => { const t = titleInput.trim(); if (t && !targetTitles.includes(t)) { setTargetTitles([...targetTitles, t]); setTitleInput(""); } }}><Plus className="w-4 h-4" /></Button>
               </div>
-              <div className="flex flex-wrap gap-2">
-                {targetTitles.map((t, i) => (
-                  <Badge key={i} variant="secondary" className="cursor-pointer" onClick={() => setTargetTitles(targetTitles.filter((_, idx) => idx !== i))}>
-                    {t} <X className="w-3 h-3 ml-1" />
-                  </Badge>
-                ))}
-              </div>
+              <div className="flex flex-wrap gap-2">{targetTitles.map((t, i) => <Badge key={i} variant="secondary" className="cursor-pointer" onClick={() => setTargetTitles(targetTitles.filter((_, idx) => idx !== i))}>{t} <X className="w-3 h-3 ml-1" /></Badge>)}</div>
             </div>
-
             <div>
               <label className="text-sm font-semibold text-foreground mb-2 block">Career Level <span className="text-xs text-muted-foreground font-normal">(select multiple)</span></label>
               <div className="flex flex-wrap gap-2">
-                {["Entry-Level / Junior", "Mid-Level", "Senior", "Manager", "Director", "VP / Senior Leadership", "C-Level / Executive"].map(level => {
+                {["Entry-Level / Junior","Mid-Level","Senior","Manager","Director","VP / Senior Leadership","C-Level / Executive"].map(level => {
                   const levels = careerLevel ? careerLevel.split(", ").filter(Boolean) : [];
                   const isSelected = levels.includes(level);
-                  return (
-                    <Badge key={level} variant={isSelected ? "default" : "outline"}
-                      className={`cursor-pointer text-xs ${isSelected ? "bg-primary text-primary-foreground" : "hover:bg-accent/10"}`}
-                      onClick={() => { const newLevels = isSelected ? levels.filter(l => l !== level) : [...levels, level]; setCareerLevel(newLevels.join(", ")); }}>
-                      {level}
-                    </Badge>
-                  );
+                  return <Badge key={level} variant={isSelected ? "default" : "outline"} className={"cursor-pointer text-xs " + (isSelected ? "bg-primary text-primary-foreground" : "hover:bg-accent/10")} onClick={() => { const nl = isSelected ? levels.filter(l => l !== level) : [...levels, level]; setCareerLevel(nl.join(", ")); }}>{level}</Badge>;
                 })}
               </div>
             </div>
-
             <div>
               <label className="text-sm font-semibold text-foreground mb-2 block">Your Skills</label>
-              {skills.length > 0 ? (
-                <div className="flex flex-wrap gap-2">{skills.map((s, i) => <Badge key={i} variant="secondary">{s}</Badge>)}</div>
-              ) : (
-                <p className="text-sm text-muted-foreground">No skills loaded. <button className="text-accent hover:underline" onClick={() => navigate("/profile")}>Add skills</button></p>
-              )}
+              {skills.length > 0 ? <div className="flex flex-wrap gap-2">{skills.map((s, i) => <Badge key={i} variant="secondary">{s}</Badge>)}</div>
+                : <p className="text-sm text-muted-foreground">No skills loaded. <button className="text-accent hover:underline" onClick={() => navigate("/profile")}>Add skills</button></p>}
             </div>
-
             <div>
               <label className="text-sm font-semibold text-foreground mb-2 block">Job Type</label>
               <div className="flex flex-wrap gap-2">
-                {JOB_TYPE_OPTIONS.map(type => (
-                  <Badge key={type} variant={jobTypes.includes(type) ? "default" : "outline"}
-                    className={`cursor-pointer capitalize ${jobTypes.includes(type) ? "bg-primary text-primary-foreground" : "hover:bg-accent/10"}`}
-                    onClick={() => toggleJobType(type)}>{type}</Badge>
-                ))}
+                {JOB_TYPE_OPTIONS.map(type => <Badge key={type} variant={jobTypes.includes(type) ? "default" : "outline"} className={"cursor-pointer capitalize " + (jobTypes.includes(type) ? "bg-primary text-primary-foreground" : "hover:bg-accent/10")} onClick={() => toggleJobType(type)}>{type}</Badge>)}
               </div>
             </div>
-
             <div className="grid sm:grid-cols-2 gap-4">
               <div>
                 <label className="text-sm font-semibold text-foreground mb-1 block">Location</label>
-                <div className="flex items-center gap-2">
-                  <MapPin className="w-4 h-4 text-muted-foreground" />
-                  <Input value={location} onChange={e => setLocation(e.target.value)} placeholder="e.g. Remote, London, Berlin, Singapore, or leave blank for global" />
-                </div>
+                <div className="flex items-center gap-2"><MapPin className="w-4 h-4 text-muted-foreground" /><Input value={location} onChange={e => setLocation(e.target.value)} placeholder="e.g. Remote, London, Berlin" /></div>
               </div>
               <div>
                 <label className="text-sm font-semibold text-foreground mb-1 block">Additional Criteria</label>
                 <Input value={customQuery} onChange={e => setCustomQuery(e.target.value)} placeholder="e.g. startup, Fortune 500..." />
               </div>
             </div>
-
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div>
+                <label className="text-sm font-semibold text-foreground mb-1 block">Posted Within</label>
+                <select className="w-full text-sm bg-background border border-input rounded-md px-3 py-2 text-foreground" value={daysOld} onChange={e => setDaysOld(Number(e.target.value))}>
+                  <option value={0}>Any time</option>
+                  <option value={1}>Last 24 hours</option>
+                  <option value={3}>Last 3 days</option>
+                  <option value={7}>Last week</option>
+                  <option value={14}>Last 2 weeks</option>
+                  <option value={30}>Last month</option>
+                  <option value={90}>Last 3 months</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-semibold text-foreground mb-1 block">Search Mode</label>
+                <select className="w-full text-sm bg-background border border-input rounded-md px-3 py-2 text-foreground" value={searchMode} onChange={e => setSearchMode(e.target.value as "quality" | "balanced" | "volume")}>
+                  <option value="quality">Quality (top 200)</option>
+                  <option value="balanced">Balanced (top 200)</option>
+                  <option value="volume">Volume (up to 800)</option>
+                </select>
+              </div>
+            </div>
             <div>
               <label className="text-sm font-semibold text-foreground mb-2 block">Minimum Fit Score: <span className="text-accent font-bold">{minFitScore}%</span></label>
               <p className="text-xs text-muted-foreground mb-2">Only show jobs with a decision score at or above this threshold</p>
@@ -372,32 +288,22 @@ export default function JobSearchPage() {
                 <Input type="number" min={0} max={100} value={minFitScore} onChange={e => setMinFitScore(Math.max(0, Math.min(100, Number(e.target.value))))} className="w-20 h-8 text-xs" />
               </div>
             </div>
-
             <div className="grid sm:grid-cols-2 gap-4">
-              <div>
-                <label className="text-sm font-semibold text-foreground mb-1 block">Min Salary</label>
-                <div className="flex items-center gap-1"><DollarSign className="w-4 h-4 text-muted-foreground" /><Input value={salaryMin} onChange={e => setSalaryMin(e.target.value)} placeholder="80,000" /></div>
-              </div>
-              <div>
-                <label className="text-sm font-semibold text-foreground mb-1 block">Max Salary</label>
-                <div className="flex items-center gap-1"><DollarSign className="w-4 h-4 text-muted-foreground" /><Input value={salaryMax} onChange={e => setSalaryMax(e.target.value)} placeholder="150,000" /></div>
-              </div>
+              <div><label className="text-sm font-semibold text-foreground mb-1 block">Min Salary</label><div className="flex items-center gap-1"><DollarSign className="w-4 h-4 text-muted-foreground" /><Input value={salaryMin} onChange={e => setSalaryMin(e.target.value)} placeholder="80,000" /></div></div>
+              <div><label className="text-sm font-semibold text-foreground mb-1 block">Max Salary</label><div className="flex items-center gap-1"><DollarSign className="w-4 h-4 text-muted-foreground" /><Input value={salaryMax} onChange={e => setSalaryMax(e.target.value)} placeholder="150,000" /></div></div>
             </div>
-
             <Button className="gradient-indigo text-white shadow-indigo-500/20 hover:opacity-90 w-full sm:w-auto" disabled={searching} onClick={() => handleSearch()}>
-              {searching ? <><Loader2 className="w-4 h-4 animate-spin mr-2" /> Searching...</> : <><Search className="w-4 h-4 mr-2" /> Search Jobs</>}
+              {searching ? <><Loader2 className="w-4 h-4 animate-spin mr-2" />Searching...</> : <><Search className="w-4 h-4 mr-2" />Search Jobs</>}
             </Button>
           </div>
         </Card>
-
         {jobs.length > 0 && (
           <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
             <h2 className="font-display font-bold text-primary text-xl">{jobs.length} Jobs Found</h2>
             <div className="flex items-center gap-3">
               <div className="flex items-center gap-2">
                 <Filter className="w-4 h-4 text-muted-foreground" />
-                <select className="text-sm bg-card border border-input rounded-md px-2 py-1 text-foreground" value={sortBy}
-                  onChange={e => { setSortBy(e.target.value as any); setVisibleCount(PAGE_SIZE); setJobs(prev => { const sorted = [...prev]; if (e.target.value === "decision") sorted.sort((a, b) => (b.decisionScore || 0) - (a.decisionScore || 0)); else if (e.target.value === "probability") sorted.sort((a, b) => (b.responseProbability || 0) - (a.responseProbability || 0)); else if (e.target.value === "newest") sorted.sort((a, b) => { if (!a.first_seen_at && !b.first_seen_at) return 0; if (!a.first_seen_at) return 1; if (!b.first_seen_at) return -1; return new Date(b.first_seen_at).getTime() - new Date(a.first_seen_at).getTime(); }); return sorted; }); }}>
+                <select className="text-sm bg-card border border-input rounded-md px-2 py-1 text-foreground" value={sortBy} onChange={e => { setSortBy(e.target.value as any); setVisibleCount(PAGE_SIZE); setJobs(prev => { const s = [...prev]; if (e.target.value === "decision") s.sort((a,b) => (b.decisionScore||0)-(a.decisionScore||0)); else if (e.target.value === "probability") s.sort((a,b) => (b.responseProbability||0)-(a.responseProbability||0)); else if (e.target.value === "newest") s.sort((a,b) => { if (!a.first_seen_at&&!b.first_seen_at) return 0; if (!a.first_seen_at) return 1; if (!b.first_seen_at) return -1; return new Date(b.first_seen_at).getTime()-new Date(a.first_seen_at).getTime(); }); return s; }); }}>
                   <option value="decision">Decision Score</option>
                   <option value="relevance">Relevance</option>
                   <option value="probability">Response Probability</option>
@@ -410,7 +316,6 @@ export default function JobSearchPage() {
             </div>
           </div>
         )}
-
         <div className="space-y-4">
           {jobs.filter(j => showFlagged || !j.is_flagged).slice(0, visibleCount).map((job, i) => {
             const prob = job.responseProbability || 0;
@@ -422,7 +327,7 @@ export default function JobSearchPage() {
             const hasDanger = job.flags?.some(f => f.severity === "danger");
             const saveKey = getJobSaveKey(job);
             return (
-              <Card key={job.id || i} className={`p-5 transition-colors ${hasDanger ? "border-destructive/30 bg-destructive/5" : hasFlags ? "border-warning/30 bg-warning/5" : "hover:border-accent/50"}`}>
+              <Card key={job.id || i} className={"p-5 transition-colors " + (hasDanger ? "border-destructive/30 bg-destructive/5" : hasFlags ? "border-warning/30 bg-warning/5" : "hover:border-accent/50")}>
                 <div className="flex flex-col sm:flex-row sm:items-start gap-4">
                   <div className="flex-1 min-w-0">
                     <div className="flex items-start gap-2 mb-1">
@@ -432,34 +337,28 @@ export default function JobSearchPage() {
                     <div className="flex flex-wrap items-center gap-3 mt-1 text-sm text-muted-foreground">
                       <span className="flex items-center gap-1"><Building2 className="w-3.5 h-3.5" /> {job.company}</span>
                       <span className="flex items-center gap-1"><MapPin className="w-3.5 h-3.5" /> {job.location}</span>
-                      {job.type && <Badge variant="outline" className="capitalize text-xs"><Briefcase className="w-3 h-3 mr-1" /> {job.type}</Badge>}
-                      {job.salary && (<span className="flex items-center gap-1"><Badge variant="outline" className="text-xs"><DollarSign className="w-3 h-3 mr-1" /> {job.salary}</Badge><SalaryBadge salary={job.salary} title={job.title} /></span>)}
+                      {job.type && <Badge variant="outline" className="capitalize text-xs"><Briefcase className="w-3 h-3 mr-1" />{job.type}</Badge>}
+                      {job.salary && <span className="flex items-center gap-1"><Badge variant="outline" className="text-xs"><DollarSign className="w-3 h-3 mr-1" />{job.salary}</Badge><SalaryBadge salary={job.salary} title={job.title} /></span>}
                       {job.source && <Badge variant="outline" className="text-xs capitalize">{job.source}</Badge>}
                     </div>
                     <p className="text-sm text-muted-foreground mt-2 leading-relaxed line-clamp-3">{job.description}</p>
                     <div className="flex flex-wrap items-center gap-3 mt-3">
-                      <div className="flex items-center gap-1">
-                        <TrustIcon className={`w-3.5 h-3.5 ${trustCfg.colorClass}`} />
-                        <span className={`text-xs font-semibold ${trustCfg.colorClass}`}>{trustCfg.label}</span>
-                      </div>
-                      <Badge variant="outline" className={`text-xs ${tag.color}`}><TagIcon className="w-3 h-3 mr-1" /> {tag.label}</Badge>
-                      <span className={`text-sm font-semibold ${getProbColor(prob)}`}>{prob}% response probability</span>
-                      {job.first_seen_at && (<span className="text-xs text-muted-foreground flex items-center gap-1"><Clock className="w-3 h-3" />{Math.round((Date.now() - new Date(job.first_seen_at).getTime()) / (1000 * 60 * 60 * 24))}d ago</span>)}
+                      <div className="flex items-center gap-1"><TrustIcon className={"w-3.5 h-3.5 " + trustCfg.colorClass} /><span className={"text-xs font-semibold " + trustCfg.colorClass}>{trustCfg.label}</span></div>
+                      <Badge variant="outline" className={"text-xs " + tag.color}><TagIcon className="w-3 h-3 mr-1" />{tag.label}</Badge>
+                      <span className={"text-sm font-semibold " + getProbColor(prob)}>{prob}% response probability</span>
+                      {job.first_seen_at && <span className="text-xs text-muted-foreground flex items-center gap-1"><Clock className="w-3 h-3" />{Math.round((Date.now()-new Date(job.first_seen_at).getTime())/(1000*60*60*24))}d ago</span>}
                     </div>
-                    {hasFlags && (<div className="flex flex-wrap gap-1.5 mt-2">{job.flags!.map((flag, fi) => (<Badge key={fi} variant="outline" className={`text-[10px] ${flag.severity === "danger" ? "border-destructive/40 text-destructive bg-destructive/5" : "border-warning/40 text-warning bg-warning/5"}`}><AlertTriangle className="w-3 h-3 mr-1" /> {flag.label}</Badge>))}</div>)}
-                    {job.matchReason && !hasDanger && (<p className="text-xs text-accent mt-2 italic">💡 {job.matchReason}</p>)}
+                    {hasFlags && <div className="flex flex-wrap gap-1.5 mt-2">{job.flags!.map((flag, fi) => <Badge key={fi} variant="outline" className={"text-[10px] " + (flag.severity==="danger" ? "border-destructive/40 text-destructive bg-destructive/5" : "border-warning/40 text-warning bg-warning/5")}><AlertTriangle className="w-3 h-3 mr-1" />{flag.label}</Badge>)}</div>}
+                    {job.matchReason && !hasDanger && <p className="text-xs text-accent mt-2 italic">💡 {job.matchReason}</p>}
                   </div>
                   <div className="flex sm:flex-col gap-2 flex-shrink-0">
                     <Button variant="outline" size="sm" className="text-xs" onClick={() => handleSaveJob(job)} disabled={!!savingJobKeys[saveKey]}>
-                      {savingJobKeys[saveKey] ? <><Loader2 className="w-3.5 h-3.5 mr-1 animate-spin" /> Saving</> : <><Plus className="w-3.5 h-3.5 mr-1" /> Save Job</>}
+                      {savingJobKeys[saveKey] ? <><Loader2 className="w-3.5 h-3.5 mr-1 animate-spin" />Saving</> : <><Plus className="w-3.5 h-3.5 mr-1" />Save Job</>}
                     </Button>
-                    <Button size="sm" className="gradient-indigo text-white text-xs" onClick={() => handleAnalyzeFit(job)}>
-                      <Target className="w-3.5 h-3.5 mr-1" /> Check My Chances
-                    </Button>
-                    {job.url && (<Button variant="outline" size="sm" className="text-xs" onClick={() => window.open(job.url, "_blank", "noopener,noreferrer")}><ExternalLink className="w-3.5 h-3.5 mr-1" /> Find & Apply</Button>)}
-                    <Button variant="ghost" size="sm" className="text-xs text-muted-foreground hover:text-destructive"
-                      onClick={async () => { const ok = await ignoreJob({ title: job.title, company: job.company, url: job.url }); if (ok) { setJobs(prev => prev.filter(j => getJobSaveKey(j) !== saveKey)); setIgnoredList(prev => [...prev, { id: '', job_title: job.title, company: job.company, job_url: job.url }]); toast.success("Job hidden — won't appear again"); } }}>
-                      <EyeOff className="w-3.5 h-3.5 mr-1" /> Ignore
+                    <Button size="sm" className="gradient-indigo text-white text-xs" onClick={() => handleAnalyzeFit(job)}><Target className="w-3.5 h-3.5 mr-1" />Check My Chances</Button>
+                    {job.url && <Button variant="outline" size="sm" className="text-xs" onClick={() => window.open(job.url, "_blank", "noopener,noreferrer")}><ExternalLink className="w-3.5 h-3.5 mr-1" />Find & Apply</Button>}
+                    <Button variant="ghost" size="sm" className="text-xs text-muted-foreground hover:text-destructive" onClick={async () => { const ok = await ignoreJob({ title: job.title, company: job.company, url: job.url }); if (ok) { setJobs(prev => prev.filter(j => getJobSaveKey(j) !== saveKey)); setIgnoredList(prev => [...prev, { id: '', job_title: job.title, company: job.company, job_url: job.url }]); toast.success("Job hidden"); } }}>
+                      <EyeOff className="w-3.5 h-3.5 mr-1" />Ignore
                     </Button>
                   </div>
                 </div>
@@ -467,39 +366,19 @@ export default function JobSearchPage() {
             );
           })}
         </div>
-
         {visibleCount < jobs.filter(j => showFlagged || !j.is_flagged).length && (
-          <div className="mt-4 text-center">
-            <Button variant="outline" onClick={() => setVisibleCount(prev => prev + PAGE_SIZE)}>
-              Load More ({jobs.filter(j => showFlagged || !j.is_flagged).length - visibleCount} remaining)
-            </Button>
-          </div>
+          <div className="mt-4 text-center"><Button variant="outline" onClick={() => setVisibleCount(prev => prev + PAGE_SIZE)}>Load More ({jobs.filter(j => showFlagged || !j.is_flagged).length - visibleCount} remaining)</Button></div>
         )}
-
         {citations.length > 0 && (
-          <div className="mt-6 pt-4 border-t border-border">
-            <p className="text-xs text-muted-foreground mb-2">Sources:</p>
-            <div className="flex flex-wrap gap-2">
-              {citations.map((c, i) => (<a key={i} href={c} target="_blank" rel="noopener noreferrer" className="text-xs text-accent hover:underline truncate max-w-xs">[{i + 1}] {c}</a>))}
-            </div>
-          </div>
+          <div className="mt-6 pt-4 border-t border-border"><p className="text-xs text-muted-foreground mb-2">Sources:</p><div className="flex flex-wrap gap-2">{citations.map((c, i) => <a key={i} href={c} target="_blank" rel="noopener noreferrer" className="text-xs text-accent hover:underline truncate max-w-xs">[{i+1}] {c}</a>)}</div></div>
         )}
-
         {!searching && jobs.length === 0 && profileLoaded && (
           <div className="text-center py-16 text-muted-foreground">
             <Search className="w-12 h-12 mx-auto mb-4 opacity-30" />
             {skills.length > 0 || targetTitles.length > 0 ? (
-              <>
-                <p className="text-lg mb-2">No jobs matched your filters</p>
-                <p className="text-sm mb-4">Try lowering the minimum fit score, removing location, or broadening job types</p>
-                <Button variant="outline" onClick={() => handleSearch({ minFitScore: 0, showFlagged: true })}>Browse all jobs (ignore filters)</Button>
-              </>
+              <><p className="text-lg mb-2">No jobs matched your filters</p><p className="text-sm mb-4">Try lowering the minimum fit score, removing location, or broadening job types</p><Button variant="outline" onClick={() => handleSearch({ minFitScore: 0, showFlagged: true })}>Browse all jobs (ignore filters)</Button></>
             ) : (
-              <>
-                <p className="text-lg mb-2">Set up your profile or search manually above</p>
-                <p className="text-sm mb-4">No skills or titles saved yet — add them to your <button className="text-accent hover:underline" onClick={() => navigate("/profile")}>Career Profile</button>, or click below to browse everything</p>
-                <Button variant="outline" onClick={() => handleSearch({ skills: [], targetTitles: [], minFitScore: 0 })}>Browse all →</Button>
-              </>
+              <><p className="text-lg mb-2">Set up your profile or search manually above</p><p className="text-sm mb-4">No skills or titles saved yet — add them to your <button className="text-accent hover:underline" onClick={() => navigate("/profile")}>Career Profile</button>, or click below to browse everything</p><Button variant="outline" onClick={() => handleSearch({ skills: [], targetTitles: [], minFitScore: 0 })}>Browse all →</Button></>
             )}
           </div>
         )}

--- a/src/services/job/service.ts
+++ b/src/services/job/service.ts
@@ -82,9 +82,7 @@ async function resilientFetch(
       return resp;
     } catch (e: any) {
       lastError = e;
-      if (attempt < maxRetries) {
-        await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
-      }
+      if (attempt < maxRetries) await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
     }
   }
   throw lastError || new Error("Fetch failed after retries");
@@ -132,7 +130,6 @@ export async function searchJobs(
 
 // ── Database-only search ───────────────────────────────────────────────
 
-// Map UI career-level labels → DB seniority values
 const CAREER_LEVEL_TO_SENIORITY: Record<string, string[]> = {
   "Entry-Level / Junior": ["entry", "junior", "intern"],
   "Mid-Level":            ["mid", "intermediate"],
@@ -143,7 +140,6 @@ const CAREER_LEVEL_TO_SENIORITY: Record<string, string[]> = {
   "C-Level / Executive":  ["c-level", "executive", "chief"],
 };
 
-// DB job_type values that map from UI job-type badges
 const JOB_TYPE_MAP: Record<string, string[]> = {
   "full-time":  ["full-time", "fulltime", "full_time"],
   "part-time":  ["part-time", "parttime", "part_time"],
@@ -155,39 +151,31 @@ export async function searchDatabaseJobs(
   filters: JobSearchFilters
 ): Promise<JobResult[]> {
   try {
-    const limit = filters.search_mode === "volume" ? 800 : 200;
+    const limit  = filters.search_mode === "volume" ? 800 : 200;
+    const offset = filters.offset ?? 0;
 
     let query = supabase
       .from("scraped_jobs")
       .select("id, title, company, location, job_type, description, job_url, quality_score, is_flagged, flag_reasons, salary, market_rate, seniority, is_remote, source, first_seen_at")
       .order("quality_score", { ascending: false })
-      .limit(limit);
+      .range(offset, offset + limit - 1);
 
     // ── Text search ────────────────────────────────────────────────────
-    // Build one OR condition per target title and per unique keyword.
-    // FIX: previously only searchTerms.split(" ")[0] (the first word) was
-    // ever searched, causing "No jobs found" for any multi-word query.
     const orParts: string[] = [];
-
     for (const t of filters.targetTitles) {
       const escaped = t.replace(/%/g, "\\%").replace(/_/g, "\\_");
       orParts.push(`title.ilike.%${escaped}%`);
     }
-
     const keywords = [filters.query, ...filters.skills]
       .flatMap(s => (s || "").split(/[\s,]+/))
       .map(s => s.replace(/[%_]/g, "").trim())
       .filter(s => s.length >= 3);
-
     const uniqueKeywords = [...new Set(keywords)];
     for (const kw of uniqueKeywords.slice(0, 10)) {
       orParts.push(`title.ilike.%${kw}%`);
       if (kw.length >= 4) orParts.push(`description.ilike.%${kw}%`);
     }
-
-    if (orParts.length > 0) {
-      query = query.or(orParts.join(","));
-    }
+    if (orParts.length > 0) query = query.or(orParts.join(","));
 
     // ── Location filter ────────────────────────────────────────────────
     if (filters.location && !/^\s*remote\s*$/i.test(filters.location)) {
@@ -195,17 +183,14 @@ export async function searchDatabaseJobs(
     }
 
     // ── Remote filter ──────────────────────────────────────────────────
-    if (filters.jobTypes.includes("remote")) {
-      query = query.eq("is_remote", true);
-    }
+    if (filters.jobTypes.includes("remote")) query = query.eq("is_remote", true);
 
     // ── Structured job type filter ─────────────────────────────────────
     const structuredTypes = filters.jobTypes
       .filter(t => !["remote", "hybrid", "in-office"].includes(t))
       .flatMap(t => JOB_TYPE_MAP[t] ?? [t]);
     if (structuredTypes.length > 0) {
-      const typeOr = structuredTypes.map(t => `job_type.ilike.%${t}%`).join(",");
-      query = query.or(typeOr);
+      query = query.or(structuredTypes.map(t => `job_type.ilike.%${t}%`).join(","));
     }
 
     // ── Seniority / career level filter ───────────────────────────────
@@ -213,8 +198,7 @@ export async function searchDatabaseJobs(
       const levels = filters.careerLevel.split(",").map(s => s.trim()).filter(Boolean);
       const seniorityValues = levels.flatMap(l => CAREER_LEVEL_TO_SENIORITY[l] ?? []);
       if (seniorityValues.length > 0) {
-        const senOr = seniorityValues.map(s => `seniority.ilike.%${s}%`).join(",");
-        query = query.or(senOr);
+        query = query.or(seniorityValues.map(s => `seniority.ilike.%${s}%`).join(","));
       }
     }
 
@@ -224,16 +208,18 @@ export async function searchDatabaseJobs(
     if (salaryMinNum && !isNaN(salaryMinNum)) query = query.gte("market_rate", salaryMinNum);
     if (salaryMaxNum && !isNaN(salaryMaxNum)) query = query.lte("market_rate", salaryMaxNum);
 
-    // ── Flagged filter ─────────────────────────────────────────────────
-    if (!filters.showFlagged) {
-      query = query.eq("is_flagged", false);
+    // ── Freshness filter ───────────────────────────────────────────────
+    const daysOld = filters.days_old ?? 0;
+    if (daysOld > 0) {
+      const cutoff = new Date(Date.now() - daysOld * 24 * 60 * 60 * 1000).toISOString();
+      query = query.gte("first_seen_at", cutoff);
     }
 
+    // ── Flagged filter ─────────────────────────────────────────────────
+    if (!filters.showFlagged) query = query.eq("is_flagged", false);
+
     const { data, error } = await query;
-    if (error) {
-      console.error("[searchDatabaseJobs] Error:", error.message);
-      return [];
-    }
+    if (error) { console.error("[searchDatabaseJobs] Error:", error.message); return []; }
 
     return (data || []).map((row: any) => ({
       id: row.id,
@@ -257,105 +243,4 @@ export async function searchDatabaseJobs(
     console.error("[searchDatabaseJobs] Exception:", e);
     return [];
   }
-}
-
-// ── AI search via edge function (async polling pattern) ────────────────
-
-export async function searchAIJobs(
-  filters: JobSearchFilters
-): Promise<{ jobs: JobResult[]; citations: string[] }> {
-  const token = await getFreshToken();
-  if (!token) {
-    console.warn("[searchAIJobs] No auth token, skipping AI search");
-    return { jobs: [], citations: [] };
-  }
-
-  const url = getEdgeFunctionUrl("search-jobs");
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "Authorization": `Bearer ${token}`,
-    "apikey": import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY,
-  };
-
-  const body = JSON.stringify({
-    skills: filters.skills,
-    jobTypes: filters.jobTypes,
-    location: filters.location,
-    query: filters.query,
-    careerLevel: filters.careerLevel,
-    targetTitles: filters.targetTitles,
-    search_mode: filters.search_mode || "balanced",
-    limit: filters.search_mode === "volume" ? 200 : 50,
-  });
-
-  const submitResp = await resilientFetch(url, { method: "POST", headers, body });
-  if (!submitResp.ok) {
-    const text = await submitResp.text().catch(() => "");
-    console.error("[searchAIJobs] Submit failed:", submitResp.status, text);
-    return { jobs: [], citations: [] };
-  }
-
-  const submitData = await submitResp.json();
-  if (submitData.jobs) {
-    return { jobs: normalizeAIJobs(submitData.jobs), citations: submitData.citations || [] };
-  }
-
-  const jobId = submitData.job_id;
-  if (!jobId) {
-    console.warn("[searchAIJobs] No job_id returned");
-    return { jobs: [], citations: [] };
-  }
-
-  const maxPolls = 15;
-  const pollInterval = 2000;
-
-  for (let i = 0; i < maxPolls; i++) {
-    await new Promise(r => setTimeout(r, pollInterval));
-    const freshToken = await getFreshToken();
-    if (freshToken) headers["Authorization"] = `Bearer ${freshToken}`;
-
-    const pollResp = await resilientFetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ job_id: jobId }),
-    });
-    if (!pollResp.ok) continue;
-
-    const pollData = await pollResp.json();
-    if (pollData.status === "completed" && pollData.jobs) {
-      return { jobs: normalizeAIJobs(pollData.jobs), citations: pollData.citations || [] };
-    }
-    if (pollData.status === "failed") {
-      console.error("[searchAIJobs] Job failed:", pollData.error);
-      return { jobs: [], citations: [] };
-    }
-  }
-
-  console.warn("[searchAIJobs] Polling timed out for job", jobId);
-  return { jobs: [], citations: [] };
-}
-
-// ── Normalize AI response jobs ─────────────────────────────────────────
-
-function normalizeAIJobs(raw: any[]): JobResult[] {
-  if (!Array.isArray(raw)) return [];
-  return raw
-    .map((item: any) => ({
-      title: item.title || "Job Opportunity",
-      company: item.company || "Company",
-      location: item.location || "Remote",
-      type: item.type || item.job_type || "full-time",
-      description: item.description || "",
-      url: normalizeJobUrl(item.url || item.job_url) || "",
-      matchReason: item.matchReason || "AI match",
-      quality_score: item.qualityScore ?? item.quality_score ?? 50,
-      is_flagged: item.is_flagged ?? false,
-      flag_reasons: item.flag_reasons ?? [],
-      salary: item.salary,
-      seniority: item.seniority,
-      is_remote: item.is_remote ?? /remote/i.test(item.location || ""),
-      source: "ai",
-      first_seen_at: item.first_seen_at,
-    }))
-    .filter((j: JobResult) => j.url && j.title !== "Job Opportunity");
-}
+}undefined

--- a/src/services/job/types.ts
+++ b/src/services/job/types.ts
@@ -44,6 +44,10 @@ export interface JobSearchFilters {
   minFitScore: number;
   showFlagged: boolean;
   search_mode?: "quality" | "balanced" | "volume";
+  /** Only return jobs posted within the last N days (0 = no limit) */
+  days_old?: number;
+  /** Pagination offset for DB-level cursor paging */
+  offset?: number;
 }
 
 export interface ParsedJobDescription {

--- a/supabase/migrations/20260414100000_fix_scraped_jobs_view.sql
+++ b/supabase/migrations/20260414100000_fix_scraped_jobs_view.sql
@@ -1,0 +1,75 @@
+-- ============================================================
+-- Fix: scraped_jobs view — computed market_rate + seniority
+-- ============================================================
+-- Context: the previous hotfix created a VIEW named scraped_jobs
+-- on top of job_postings to surface employer postings to job seekers.
+-- That view left market_rate and seniority as NULL because it did not
+-- map salary_min/salary_max to market_rate or experience_level to seniority.
+-- This migration re-creates the view with those columns computed.
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.scraped_jobs AS
+SELECT
+  jp.id,
+  jp.title,
+  jp.company,
+  jp.location,
+
+  -- job_type: use job_type column; fall back to remote_type for older rows
+  COALESCE(jp.job_type, jp.remote_type) AS job_type,
+
+  jp.description,
+  NULL::text  AS source_id,
+
+  -- is_remote: explicit flag takes priority, then infer from remote_type
+  COALESCE(
+    jp.is_remote,
+    jp.remote_type IN ('remote', 'hybrid')
+  )           AS is_remote,
+
+  -- FIX: map experience_level to seniority so the career-level filter works
+  jp.experience_level AS seniority,
+
+  -- FIX: compute market_rate from salary_min/max so the salary filter works
+  CASE
+    WHEN jp.salary_min IS NOT NULL AND jp.salary_max IS NOT NULL
+      THEN (jp.salary_min + jp.salary_max) / 2
+    WHEN jp.salary_max IS NOT NULL THEN jp.salary_max
+    WHEN jp.salary_min IS NOT NULL THEN jp.salary_min
+    ELSE NULL
+  END         AS market_rate,
+
+  -- Human-readable salary string for display
+  CASE
+    WHEN jp.salary_min IS NOT NULL AND jp.salary_max IS NOT NULL
+      THEN '$' || to_char(jp.salary_min, 'FM999,999')
+        || ' - $' || to_char(jp.salary_max, 'FM999,999')
+    WHEN jp.salary_max IS NOT NULL
+      THEN 'Up to $' || to_char(jp.salary_max, 'FM999,999')
+    WHEN jp.salary_min IS NOT NULL
+      THEN 'From $' || to_char(jp.salary_min, 'FM999,999')
+    ELSE NULL
+  END         AS salary,
+
+  -- Employer postings start at quality_score 50; no fake-job flags
+  50           AS quality_score,
+  false        AS is_flagged,
+  NULL::jsonb  AS flag_reasons,
+  NULL::jsonb  AS compensation_breakdown,
+  NULL::jsonb  AS salary_range_estimated,
+  NULL::text   AS industry,
+
+  jp.created_at,
+  jp.created_at  AS first_seen_at,
+  jp.updated_at  AS last_seen_at,
+  NULL::text     AS job_url,
+  'internal'     AS source
+
+FROM public.job_postings jp
+WHERE jp.status = 'active';
+
+-- Grant read access to authenticated users and anon
+GRANT SELECT ON public.scraped_jobs TO anon, authenticated;
+
+COMMENT ON VIEW public.scraped_jobs IS
+  'Unified job feed: surfaces active employer postings with computed market_rate and seniority for job-seeker search filters.';


### PR DESCRIPTION
## Summary

- **DB migration**: `scraped_jobs` view now computes `market_rate` from `(salary_min + salary_max) / 2` and maps `experience_level → seniority` — these were NULL before, breaking the salary and career-level filters
- **Freshness filter**: new `days_old` param prunes stale postings at DB level (any time / 24h / 3d / 7d / 14d / 30d / 90d)
- **Offset pagination**: `searchDatabaseJobs` now uses `.range(offset, offset+limit-1)` instead of `.limit()` to support future page-2+ fetching without re-querying
- **Posted Within dropdown**: new UI control wired to `days_old` filter
- **Search Mode dropdown**: `quality / balanced / volume` now visible in the UI (was hidden state)
- **Types**: `JobSearchFilters` extended with `days_old?: number` and `offset?: number`

## Files changed
- `supabase/migrations/20260414100000_fix_scraped_jobs_view.sql` (new)
- `src/services/job/types.ts`
- `src/services/job/service.ts`
- `src/pages/JobSearch.tsx`