### PR TITLE
Remove Firecrawl dependency — database-only job search (zero cost)

### DIFF
--- a/src/pages/JobSearch.tsx
+++ b/src/pages/JobSearch.tsx
@@ -86,7 +86,7 @@ export default function JobSearchPage() {
   const [citations, setCitations] = useState<string[]>([]);
   const [searching, setSearching] = useState(false);
   const [profileLoaded, setProfileLoaded] = useState(false);
-  const [searchSource, setSearchSource] = useState<"all" | "ai" | "database">("all");
+  const [searchSource, setSearchSource] = useState<"all" | "ai" | "database">("database");
   const [sortBy, setSortBy] = useState<"relevance" | "probability" | "newest" | "decision">("decision");
   const [showFlagged, setShowFlagged] = useState(true);
   const [historicalOutcomes, setHistoricalOutcomes] = useState<HistoricalOutcomes | undefined>();
@@ -212,11 +212,9 @@ export default function JobSearchPage() {
             <div>
               <label className="text-sm font-semibold text-foreground mb-2 block">Search Source</label>
               <div className="flex gap-2">
-                {(["all", "database", "ai"] as const).map(src => (
-                  <Badge key={src} variant={searchSource === src ? "default" : "outline"} className={"cursor-pointer capitalize " + (searchSource === src ? "bg-primary text-primary-foreground" : "hover:bg-accent/10")} onClick={() => setSearchSource(src)}>
-                    {src === "all" ? <><Database className="w-3 h-3 mr-1" />All Sources</> : src === "database" ? <><Database className="w-3 h-3 mr-1" />Job Database</> : <><Search className="w-3 h-3 mr-1" />AI Search</>}
-                  </Badge>
-                ))}
+                <Badge variant="default" className="bg-primary text-primary-foreground">
+                  <Database className="w-3 h-3 mr-1" />Job Database
+                </Badge>
               </div>
             </div>
             <div>

--- a/src/services/job/service.ts
+++ b/src/services/job/service.ts
@@ -42,6 +42,7 @@ export function normalizeJobUrl(rawUrl?: string | null): string {
 
 // ── Fresh token helper ─────────────────────────────────────────────────
 
+// NOTE: Only used by AI search (currently disabled). Keep for future re-enablement.
 async function getFreshToken(): Promise<string | null> {
   try {
     const { data } = await supabase.auth.refreshSession();
@@ -54,6 +55,7 @@ async function getFreshToken(): Promise<string | null> {
 
 // ── Resilient fetch with retries ───────────────────────────────────────
 
+// NOTE: Only used by AI search (currently disabled). Keep for future re-enablement.
 async function resilientFetch(
   url: string,
   options: RequestInit,

--- a/src/services/job/service.ts
+++ b/src/services/job/service.ts
@@ -95,37 +95,14 @@ function getEdgeFunctionUrl(name: string): string {
   return `https://${projectId}.supabase.co/functions/v1/${name}`;
 }
 
-// ── Search Jobs (main entry — async polling) ───────────────────────────
+// ── Search Jobs (main entry — database-only mode) ────────────────────────
 
+// Main entry: database-only search (AI/Firecrawl disabled — zero external cost)
 export async function searchJobs(
   filters: JobSearchFilters
 ): Promise<{ jobs: JobResult[]; citations: string[] }> {
-  const source = filters.searchSource || "all";
-
-  const dbPromise = (source === "all" || source === "database")
-    ? searchDatabaseJobs(filters)
-    : Promise.resolve([]);
-
-  const aiPromise = (source === "all" || source === "ai")
-    ? searchAIJobs(filters).catch(e => {
-        console.error("[searchJobs] AI search failed (continuing with DB):", e);
-        return { jobs: [] as JobResult[], citations: [] as string[] };
-      })
-    : Promise.resolve({ jobs: [] as JobResult[], citations: [] as string[] });
-
-  const [dbJobs, aiResult] = await Promise.all([dbPromise, aiPromise]);
-  const aiJobs = aiResult.jobs || [];
-  const citations = aiResult.citations || [];
-
-  const seen = new Set<string>();
-  const merged: JobResult[] = [];
-  for (const job of [...aiJobs, ...dbJobs]) {
-    const key = `${(job.url || "").toLowerCase()}|${job.title.toLowerCase()}|${job.company.toLowerCase()}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    merged.push(job);
-  }
-  return { jobs: merged, citations };
+  const dbJobs = await searchDatabaseJobs(filters);
+  return { jobs: dbJobs, citations: [] };
 }
 
 // ── Database-only search ───────────────────────────────────────────────
@@ -243,4 +220,14 @@ export async function searchDatabaseJobs(
     console.error("[searchDatabaseJobs] Exception:", e);
     return [];
   }
-}undefined
+}
+
+// ── AI search (disabled in database-only mode) ─────────────────────────
+
+// AI search via edge function — DISABLED (database-only mode, zero cost)
+export async function searchAIJobs(
+  filters: JobSearchFilters
+): Promise<{ jobs: JobResult[]; citations: string[] }> {
+  console.info("[searchAIJobs] Skipped — database-only mode active. AI search disabled to operate at zero cost.");
+  return { jobs: [], citations: [] };
+}

--- a/supabase/functions/search-jobs/index.ts
+++ b/supabase/functions/search-jobs/index.ts
@@ -1,3 +1,16 @@
+/**
+ * SEARCH-JOBS EDGE FUNCTION — CURRENTLY DISABLED
+ *
+ * This edge function is not called in database-only mode.
+ * Job search operates via direct Supabase queries from the client.
+ *
+ * To re-enable AI search:
+ * 1. Set feature flag 'ai_search' to true in feature_flags table
+ * 2. Set FIRECRAWL_API_KEY in Supabase secrets
+ * 3. Restore the dual-source logic in src/services/job/service.ts searchJobs()
+ * 4. Deploy this function: supabase functions deploy search-jobs
+ */
+
 // iCareerOS v5 â search-jobs Edge Function
 // Zero-dependency: uses Deno.serve + inline PostgREST client.
 // Replaces the old 707-line Firecrawl-based search with direct job_postings queries.

--- a/supabase/migrations/20260414_ai_search_feature_flag.sql
+++ b/supabase/migrations/20260414_ai_search_feature_flag.sql
@@ -1,0 +1,6 @@
+-- Feature flag to control AI-powered job search (Firecrawl)
+-- Currently OFF — operating in database-only mode at zero cost
+-- Turn ON when ready to re-enable AI search with a Firecrawl API key
+INSERT INTO feature_flags (key, enabled, description) VALUES
+  ('ai_search', false, 'Enable AI-powered web search via Firecrawl API (adds external cost)')
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
Closes #177

## What this does
- Switches job search to database-only mode (no Firecrawl, no edge function calls)
- Fixes multi-word search bug (searches all terms, not just the first word)
- Wires all UI filters (remote, job type, career level, salary) to the database query
- Hides AI search source option from UI
- Adds ai_search feature flag (defaults to OFF) for future re-enablement
- Marks edge function and AI-only helpers as disabled with docs

## What stays the same
- All client-side scoring: trust engine, quality scores, response probability, strategy
- Save/ignore jobs
- URL normalization
- Benefits extraction and matching
- Orchestrator pipeline structure

## Cost impact
- Before: Every search triggers Firecrawl API calls via edge function (paid)
- After: Every search queries Supabase directly (included in free tier)

## Notes
- Tasks 4 & 5 (multi-word search fix, filter wiring) were already implemented in `dev` — skipped as instructed

## Testing
- [ ] Search with a keyword → returns results from scraped_jobs
- [ ] Search with multiple words → matches on ALL words
- [ ] Remote filter works
- [ ] Job type filter works
- [ ] Career level filter works
- [ ] No network calls to search-jobs edge function (check Network tab)
- [ ] No console errors related to Firecrawl or AI search
- [ ] Console shows "[searchAIJobs] Skipped" info message