### PR TITLE
fix(scrape-url): resolve 403 errors with browser headers + retry

### DIFF
--- a/supabase/functions/scrape-url/index.ts
+++ b/supabase/functions/scrape-url/index.ts
@@ -8,10 +8,15 @@
  *  2. Fallback: Cheerio-based structured DOM extraction (handles ATS boards,
  *     JS-heavy pages, and complex layouts that defeat regex stripping)
  *
+ * Fetch strategy:
+ *  - Attempt 1: full browser headers (Chrome 124 UA)
+ *  - Attempt 2 on 403/429: stripped headers (no Sec-* / Cookie pressure)
+ *  Both attempts share the same extraction pipeline.
+ *
  * Security:
  *  - SSRF protection via validatePublicUrl (blocks private IPs, loopback, etc.)
  *  - Rate limited: 10 requests / minute / user (in-memory, best-effort)
- *  - 15-second fetch timeout
+ *  - 15-second per-attempt timeout
  *
  * Response shape:
  *  { success: true,  markdown: string, title?: string, usedFallback?: boolean }
@@ -33,10 +38,60 @@ const corsHeaders = {
 };
 
 // ---------------------------------------------------------------------------
-// Primary extractor — lightweight regex, no deps
+// Browser header presets
 // ---------------------------------------------------------------------------
 
-/** Strip HTML tags and collapse whitespace into readable plain text. */
+/** Full Chrome 124 headers — works for most public ATS boards. */
+const HEADERS_CHROME: Record<string, string> = {
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+  "Accept":
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+  "Accept-Language": "en-US,en;q=0.9",
+  "Accept-Encoding": "gzip, deflate, br",
+  "Sec-Fetch-Dest": "document",
+  "Sec-Fetch-Mode": "navigate",
+  "Sec-Fetch-Site": "none",
+  "Sec-Fetch-User": "?1",
+  "Upgrade-Insecure-Requests": "1",
+  "Cache-Control": "no-cache",
+  "Pragma": "no-cache",
+};
+
+/**
+ * Stripped fallback headers — no Sec-* headers, minimal footprint.
+ * Some CDNs (Cloudflare) let this through when the full set triggers a WAF rule.
+ */
+const HEADERS_MINIMAL: Record<string, string> = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+  "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+  "Accept-Language": "en-US,en;q=0.5",
+};
+
+// Sites that require login — we can't scrape them server-side.
+// Return a helpful, specific message instead of a generic 403.
+const LOGIN_WALL_PATTERNS: Array<{ pattern: RegExp; name: string }> = [
+  { pattern: /linkedin\.com/i,  name: "LinkedIn" },
+  { pattern: /indeed\.com/i,    name: "Indeed" },
+  { pattern: /glassdoor\.com/i, name: "Glassdoor" },
+  { pattern: /ziprecruiter\.com/i, name: "ZipRecruiter" },
+  { pattern: /monster\.com/i,   name: "Monster" },
+];
+
+function loginWallMessage(url: string): string | null {
+  for (const { pattern, name } of LOGIN_WALL_PATTERNS) {
+    if (pattern.test(url)) {
+      return `${name} blocks server-side access to job postings. Please open the job page in your browser, copy the description, and paste it below.`;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// HTML extractor helpers
+// ---------------------------------------------------------------------------
+
 function htmlToText(html: string): string {
   return html
     .replace(/<script[\s\S]*?<\/script>/gi, " ")
@@ -57,22 +112,80 @@ function htmlToText(html: string): string {
     .trim();
 }
 
-/**
- * Run the primary (regex-based) extraction pass.
- * Returns null when the result is too short to be useful.
- */
 function extractPrimary(html: string): { text: string; title?: string } | null {
   const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
   const title = titleMatch?.[1]?.trim();
-
-  // Prefer semantic containers for a cleaner signal.
   const mainMatch =
     html.match(/<main[\s\S]*?<\/main>/i) ||
     html.match(/<article[\s\S]*?<\/article>/i);
   const rawText = htmlToText(mainMatch?.[0] ?? html);
-
   if (!rawText || rawText.length < 150) return null;
   return { text: rawText.slice(0, 8_000), title };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch with automatic retry on 403 / 429
+// ---------------------------------------------------------------------------
+
+interface FetchAttempt {
+  ok: boolean;
+  status?: number;
+  html?: string;
+  contentType?: string;
+  error?: string;
+}
+
+async function fetchWithFallback(url: string): Promise<FetchAttempt> {
+  // Attempt 1 — full Chrome headers
+  try {
+    const res = await fetch(url, {
+      headers: HEADERS_CHROME,
+      signal: AbortSignal.timeout(15_000),
+      redirect: "follow",
+    });
+
+    if (res.ok) {
+      return {
+        ok: true,
+        status: res.status,
+        html: await res.text(),
+        contentType: res.headers.get("content-type") ?? "",
+      };
+    }
+
+    // On 403/429 try a second attempt with minimal headers
+    if (res.status === 403 || res.status === 429) {
+      await res.body?.cancel();
+      console.log(`[scrape-url] ${res.status} on attempt 1, retrying with minimal headers: ${url}`);
+
+      const res2 = await fetch(url, {
+        headers: HEADERS_MINIMAL,
+        signal: AbortSignal.timeout(15_000),
+        redirect: "follow",
+      });
+
+      if (res2.ok) {
+        return {
+          ok: true,
+          status: res2.status,
+          html: await res2.text(),
+          contentType: res2.headers.get("content-type") ?? "",
+        };
+      }
+
+      // Both attempts failed — return the second status
+      await res2.body?.cancel();
+      return { ok: false, status: res2.status };
+    }
+
+    // Other non-OK status (404, 500, etc.) — no retry
+    await res.body?.cancel();
+    return { ok: false, status: res.status };
+
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg };
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -127,54 +240,49 @@ Deno.serve(async (req) => {
   }
   const url = urlValidation.url;
 
-  // ── Fetch ─────────────────────────────────────────────────────────────────
-  let html: string;
+  // ── Fetch (with 403 retry) ────────────────────────────────────────────────
+  const attempt = await fetchWithFallback(url);
 
-  try {
-    const res = await fetch(url, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (compatible; iCareerOS/1.0; +https://icareeros.com)",
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.9",
-        "Cache-Control": "no-cache",
-      },
-      signal: AbortSignal.timeout(15_000),
-    });
+  if (!attempt.ok) {
+    // Check if it's a known login-wall site before giving a generic error
+    const loginMsg = loginWallMessage(url);
 
-    if (!res.ok) {
-      return json(
-        {
-          success: false,
-          error: `Could not fetch the page (HTTP ${res.status}). Please paste the job description manually.`,
-          extractionFailed: true,
-        }
-      );
-    }
-
-    const contentType = res.headers.get("content-type") ?? "";
-    if (
-      !contentType.includes("text/html") &&
-      !contentType.includes("text/plain")
-    ) {
+    if (attempt.error) {
+      const isTimeout =
+        attempt.error.toLowerCase().includes("timeout") ||
+        attempt.error.toLowerCase().includes("abort");
       return json({
         success: false,
-        error: "The page returned a non-HTML response. Please paste the job description manually.",
         extractionFailed: true,
+        error: isTimeout
+          ? "The page took too long to load. Please paste the job description manually."
+          : `Unable to reach the page. Please paste the job description manually.`,
       });
     }
 
-    html = await res.text();
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : "Unknown error";
-    const isTimeout = msg.toLowerCase().includes("timeout") || msg.toLowerCase().includes("abort");
     return json({
       success: false,
-      error: isTimeout
-        ? "The page took too long to load. Please paste the job description manually."
-        : `Failed to fetch the URL: ${msg}. Please paste the job description manually.`,
       extractionFailed: true,
+      error: loginMsg ??
+        `Could not load the page (HTTP ${attempt.status}). Please paste the job description manually.`,
+    });
+  }
+
+  const { html, contentType = "" } = attempt;
+
+  if (!html) {
+    return json({
+      success: false,
+      extractionFailed: true,
+      error: "The page returned no content. Please paste the job description manually.",
+    });
+  }
+
+  if (!contentType.includes("text/html") && !contentType.includes("text/plain")) {
+    return json({
+      success: false,
+      extractionFailed: true,
+      error: "The page returned a non-HTML response. Please paste the job description manually.",
     });
   }
 


### PR DESCRIPTION
## Problem
The `iCareerOS/1.0` User-Agent was immediately blocked (HTTP 403) by Cloudflare WAF and most major job board servers.

## Fix
- **Chrome 124 UA** with full `Sec-Fetch-*`, `Accept-Encoding`, `Upgrade-Insecure-Requests` headers
- **Auto-retry on 403/429** with stripped minimal headers — bypasses WAF rules triggered by `Sec-Fetch-*` presence
- **Login-wall detection** for LinkedIn, Indeed, Glassdoor, ZipRecruiter, Monster — returns site-specific message instead of generic 403

## Test
- [ ] Greenhouse board URL → fetches successfully
- [ ] Lever board URL → fetches successfully  
- [ ] LinkedIn URL → returns helpful message (not generic 403)
- [ ] Indeed URL → returns helpful message
- [ ] Arbitrary company careers page → fetches successfully