### PR TITLE
feat(scrape-url): adaptive learning agent + smart job parser

### DIFF
--- a/supabase/functions/_shared/extraction-cache.ts
+++ b/supabase/functions/_shared/extraction-cache.ts
@@ -1,0 +1,192 @@
+/**
+ * extraction-cache.ts — Adaptive domain learning for scrape-url
+ *
+ * Reads and writes to the `domain_extraction_hints` table so the agent
+ * gets smarter with every run:
+ *
+ *  • On load  — fetches the best-known strategy for this domain
+ *  • On win   — increments success_count, updates best_strategy + best_selector
+ *  • On fail  — increments failure_count, notes the blocking reason
+ *
+ * Strategies stored (in priority order if a winner is known):
+ *   'greenhouse-api' | 'lever-api' | 'smartrecruiters-api' | 'breezy-api'
+ *   'ashby-ssr' | 'cheerio:{selector}' | 'html-fetch'
+ *   'login-wall' | 'ip-blocked'
+ *
+ * Runtime: Deno (Supabase Edge Functions)
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DomainHint {
+  domain: string;
+  bestStrategy: string | null;
+  bestSelector: string | null;
+  successCount: number;
+  failureCount: number;
+  notes: string | null;
+}
+
+export interface ExtractionOutcome {
+  success: boolean;
+  strategy: string;
+  selector?: string;
+  notes?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Supabase admin client (service role — bypasses RLS)
+// ---------------------------------------------------------------------------
+
+function getAdminClient() {
+  // Import inline to avoid top-level await issues in Deno edge env
+  // deno-lint-ignore no-explicit-any
+  const { createClient } = (globalThis as any).__supabaseModule ??
+    { createClient: null };
+
+  // Fallback: direct import
+  return null; // resolved at call site
+}
+
+// ---------------------------------------------------------------------------
+// Domain normalizer
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a URL to a domain key.
+ * e.g. https://boards.greenhouse.io/anthropic/jobs/123 → "boards.greenhouse.io"
+ */
+export function domainKey(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return url.slice(0, 100);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cache read
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the known hint for a domain.
+ * Returns null if no data exists (first time seeing this domain).
+ *
+ * @param supabaseAdmin  Supabase client with service role key
+ * @param domain         Normalized domain key (from domainKey())
+ */
+export async function getDomainHint(
+  supabaseAdmin: any,
+  domain: string
+): Promise<DomainHint | null> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("domain_extraction_hints")
+      .select("domain, best_strategy, best_selector, success_count, failure_count, notes")
+      .eq("domain", domain)
+      .maybeSingle();
+
+    if (error || !data) return null;
+
+    return {
+      domain: data.domain,
+      bestStrategy: data.best_strategy,
+      bestSelector: data.best_selector,
+      successCount: data.success_count ?? 0,
+      failureCount: data.failure_count ?? 0,
+      notes: data.notes,
+    };
+  } catch (e) {
+    console.warn("[extraction-cache] getDomainHint error:", e);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cache write
+// ---------------------------------------------------------------------------
+
+/**
+ * Record an extraction outcome for a domain.
+ * Uses upsert so first-time domains are inserted automatically.
+ *
+ * @param supabaseAdmin  Supabase client with service role key
+ * @param domain         Normalized domain key
+ * @param outcome        What happened (success/failure + which strategy)
+ */
+export async function recordOutcome(
+  supabaseAdmin: any,
+  domain: string,
+  outcome: ExtractionOutcome
+): Promise<void> {
+  try {
+    const now = new Date().toISOString();
+    const baseUpsert: Record<string, unknown> = {
+      domain,
+      last_seen_at: now,
+    };
+
+    if (outcome.success) {
+      // On success, update best_strategy + selector + increment counter
+      await supabaseAdmin.from("domain_extraction_hints").upsert(
+        {
+          ...baseUpsert,
+          best_strategy: outcome.strategy,
+          best_selector: outcome.selector ?? null,
+          last_success_at: now,
+          notes: outcome.notes ?? null,
+          // Increment success_count using SQL expression via RPC
+        },
+        { onConflict: "domain", ignoreDuplicates: false }
+      );
+
+      // Separately increment the counter (upsert can't do this atomically easily)
+      await supabaseAdmin.rpc("increment_extraction_success", { p_domain: domain });
+    } else {
+      await supabaseAdmin.from("domain_extraction_hints").upsert(
+        {
+          ...baseUpsert,
+          last_failure_at: now,
+          notes: outcome.notes ?? null,
+        },
+        { onConflict: "domain", ignoreDuplicates: false }
+      );
+
+      await supabaseAdmin.rpc("increment_extraction_failure", { p_domain: domain });
+    }
+  } catch (e) {
+    // Non-fatal — cache write failures never block the main flow
+    console.warn("[extraction-cache] recordOutcome error:", e);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Strategy ranker
+// ---------------------------------------------------------------------------
+
+/**
+ * Given the known hint for a domain, return the ordered list of strategies
+ * the agent should try. Known winners go first.
+ *
+ * @param hint         Hint from DB (or null if first time)
+ * @param defaultOrder Default order to use when no hint exists
+ */
+export function rankedStrategies(
+  hint: DomainHint | null,
+  defaultOrder: string[]
+): string[] {
+  if (!hint?.bestStrategy) return defaultOrder;
+
+  // If a strategy is known to work, put it first
+  const winner = hint.bestStrategy;
+  const rest = defaultOrder.filter((s) => s !== winner);
+
+  // If the domain is known login-wall or ip-blocked, short-circuit
+  if (winner === "login-wall" || winner === "ip-blocked") {
+    return [winner]; // only this strategy — will return helpful message immediately
+  }
+
+  return [winner, ...rest];
+}

--- a/supabase/functions/_shared/job-parser.ts
+++ b/supabase/functions/_shared/job-parser.ts
@@ -1,0 +1,359 @@
+/**
+ * job-parser.ts — Section-aware job description parser
+ *
+ * Splits raw job text into labeled sections, then:
+ *   KEEP  — skills-relevant content (responsibilities, requirements, qualifications)
+ *   STRIP — noise that pollutes the AI analysis engine (benefits, EEO, apply info)
+ *   META  — useful metadata (title, location, salary) → preserved separately
+ *
+ * The result is a clean text block containing ONLY content the AI needs to
+ * accurately score skills and identify gaps, without benefits or legal boilerplate
+ * inflating the skill extraction.
+ *
+ * Runtime: Deno (Supabase Edge Functions — no Node.js APIs)
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SectionTag = "keep" | "strip" | "meta" | "unknown";
+
+export interface ParsedSection {
+  header: string;
+  body: string;
+  tag: SectionTag;
+  reason?: string;
+}
+
+export interface JobParseResult {
+  /** Clean job description — only KEEP sections. Use this for AI analysis. */
+  cleanDescription: string;
+  /** Metadata pulled out (title, location, salary, company, type). */
+  meta: JobMeta;
+  /** All parsed sections with tags (for debugging / observability). */
+  sections: ParsedSection[];
+  /** Number of characters stripped. */
+  strippedChars: number;
+  /** True if the result looks like a real job description. */
+  isJobDescription: boolean;
+}
+
+export interface JobMeta {
+  title?: string;
+  company?: string;
+  location?: string;
+  salary?: string;
+  jobType?: string; // full-time, part-time, contract, etc.
+  remote?: boolean;
+  department?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Section classification rules
+// ---------------------------------------------------------------------------
+
+/**
+ * Headers that indicate KEEP sections.
+ * Content under these headers contains skills / requirements the AI needs.
+ */
+const KEEP_HEADERS: RegExp[] = [
+  /^(job\s*)?description/i,
+  /^(about|overview of)\s*(the\s*)?(role|position|opportunity|job)/i,
+  /^the\s*role/i,
+  /^position\s*(overview|summary|description)/i,
+  /^role\s*(overview|summary|description)/i,
+  /^what\s*you.?ll\s*(do|be\s*doing|own|build|drive|lead)/i,
+  /^(key\s*)?(responsibilities|duties|accountabilities)/i,
+  /^(your\s*)?day[- ]to[- ]day/i,
+  /^what\s*we.?re\s*looking\s*for/i,
+  /^(minimum\s*)?(required\s*)?(qualifications?|requirements?)/i,
+  /^(basic|minimum|preferred|desired|nice[- ]to[- ]have)\s*(qualifications?|requirements?)/i,
+  /^(technical\s*)?(skills?|competencies|expertise)/i,
+  /^(must[- ]have|need\s*to\s*have)/i,
+  /^(preferred|bonus)\s*(skills?|qualifications?|experience)/i,
+  /^(minimum|required)\s*experience/i,
+  /^experience\s*(required|and\s*skills?)/i,
+  /^what\s*you\s*(bring|offer|have)/i,
+  /^your\s*(background|profile|skills?|experience)/i,
+  /^(core\s*)?competencies/i,
+  /^(key\s*)?(success\s*)?factors/i,
+  /^(about\s*the\s*)?(team|project|product)/i,
+  /^technologies?(\s*stack)?/i,
+  /^tech\s*stack/i,
+  /^tools?\s*(&|and)\s*technologies?/i,
+];
+
+/**
+ * Headers that indicate STRIP sections.
+ * Content here doesn't contribute to skills analysis — strip it.
+ */
+const STRIP_HEADERS: RegExp[] = [
+  // Benefits & compensation
+  /^(what\s*we\s*offer|what\s*you.?ll\s*get|why\s*(join|work(\s*with)?\s*us)|our\s*offer)/i,
+  /^(employee\s*)?(benefits?|perks?|rewards?)/i,
+  /^compensation(\s*&\s*benefits?)?/i,
+  /^(total\s*)?rewards?/i,
+  /^(salary|pay)\s*(range|information|details?)/i,
+  /^(our\s*)?(package|offerings?)/i,
+  /^why\s*(this\s*role|this\s*opportunity)/i,
+  /^life\s*at\s*/i,
+  /^working\s*at\s*/i,
+  // Apply / process info
+  /^(how\s*to\s*)?apply/i,
+  /^application\s*(process|instructions?|details?)/i,
+  /^(next\s*)?steps?/i,
+  /^interview\s*(process|stages?)/i,
+  /^hiring\s*(process|stages?)/i,
+  /^what\s*(to\s*expect|happens\s*next)/i,
+  // EEO / legal boilerplate
+  /^equal\s*(opportunity|employment)/i,
+  /^eeo/i,
+  /^(our\s*)?commitment\s*to\s*(diversity|inclusion|equity)/i,
+  /^diversity(\s*&\s*(equity\s*&\s*)?inclusion)?/i,
+  /^(we\s*(are|value|celebrate)\s*(an?\s*)?)?(equal|inclusive|diverse)/i,
+  /^(disability|accommodation)/i,
+  /^notice\s*(to\s*)?(staffing\s*)?agencies?/i,
+  /^(no\s*)?(recruiters?|agencies?|third[- ]party)/i,
+  /^unsolicited\s*(resumes?|applications?)/i,
+  // Company marketing fluff
+  /^(about\s*(the\s*)?company|company\s*overview|who\s*we\s*are)/i,
+  /^our\s*(story|mission|vision|values?|culture)/i,
+  /^mission(\s*&\s*vision)?/i,
+  /^(our\s*)?culture(\s*&\s*values?)?/i,
+  // Disclaimers
+  /^(important\s*)?(notice|disclaimer|note)/i,
+  /^please\s*note/i,
+  /^(job\s*)?(id|code|number|ref|reference)\s*:/i,
+];
+
+/**
+ * Body-level patterns that should be stripped even outside labeled sections.
+ * These are inline boilerplate that appears without a section header.
+ */
+const STRIP_INLINE_PATTERNS: RegExp[] = [
+  // EEO statements
+  /we\s*(are|provide)\s*an?\s*equal\s*(opportunity|employment)/i,
+  /regardless\s*of\s*(race|color|gender|sex|age|national\s*origin|religion|disability|veteran)/i,
+  /all\s*qualified\s*applicants\s*will\s*receive\s*consideration/i,
+  /we\s*do\s*not\s*discriminate/i,
+  /protected\s*(characteristics?|class|veteran)/i,
+  // Agency notices
+  /we\s*do\s*not\s*accept\s*(unsolicited\s*)?(resumes?|applications?)\s*from\s*(recruiters?|agencies?|staffing)/i,
+  /to\s*all\s*recruitment\s*agencies/i,
+  /third[- ]party\s*(recruiters?|agencies?)/i,
+  // Legal / disclaimer
+  /this\s*(job\s*)?posting\s*(is|was)\s*(not|no\s*longer)\s*(accepting|active|open)/i,
+  /application\s*deadline\s*:/i,
+];
+
+/**
+ * Salary / compensation patterns to extract as metadata (not for AI analysis).
+ */
+const SALARY_PATTERN =
+  /\$[\d,]+(?:\s*[-–]\s*\$[\d,]+)?(?:\s*(?:per\s*year|\/yr|annually|\/year|\/hour|\/hr|per\s*hour|k))?/i;
+
+const JOB_TYPE_PATTERN =
+  /\b(full[- ]time|part[- ]time|contract|temporary|temp|freelance|internship|intern|co[- ]op)\b/i;
+
+const REMOTE_PATTERN =
+  /\b(fully\s*remote|remote[- ]first|remote\s*ok|work\s*from\s*home|wfh|hybrid|on[- ]site|in[- ]office)\b/i;
+
+// ---------------------------------------------------------------------------
+// Section splitter
+// ---------------------------------------------------------------------------
+
+/**
+ * Split raw text into sections based on header detection.
+ * Headers are lines that are short, possibly styled (#, **, ALL CAPS).
+ */
+function splitIntoSections(text: string): Array<{ header: string; body: string }> {
+  const lines = text.split("\n");
+  const sections: Array<{ header: string; body: string }> = [];
+  let currentHeader = "";
+  let currentBody: string[] = [];
+
+  const isHeader = (line: string): boolean => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.length > 120) return false;
+    // Markdown headers
+    if (/^#{1,4}\s+/.test(trimmed)) return true;
+    // Bold text
+    if (/^\*{1,2}[^*]+\*{1,2}$/.test(trimmed)) return true;
+    // ALL CAPS line (at least 3 words or 10+ chars)
+    if (trimmed === trimmed.toUpperCase() && trimmed.length >= 8 && /[A-Z]{2,}/.test(trimmed)) return true;
+    // Ends with colon and is short
+    if (trimmed.endsWith(":") && trimmed.length <= 60 && !/^[-•*]/.test(trimmed)) return true;
+    return false;
+  };
+
+  const cleanHeader = (h: string) =>
+    h.replace(/^#+\s*/, "").replace(/^\*+|\*+$/g, "").replace(/:$/, "").trim();
+
+  for (const line of lines) {
+    if (isHeader(line)) {
+      // Save previous section
+      if (currentHeader || currentBody.length > 0) {
+        sections.push({ header: cleanHeader(currentHeader), body: currentBody.join("\n").trim() });
+      }
+      currentHeader = line.trim();
+      currentBody = [];
+    } else {
+      currentBody.push(line);
+    }
+  }
+
+  // Last section
+  if (currentHeader || currentBody.length > 0) {
+    sections.push({ header: cleanHeader(currentHeader), body: currentBody.join("\n").trim() });
+  }
+
+  return sections;
+}
+
+// ---------------------------------------------------------------------------
+// Section classifier
+// ---------------------------------------------------------------------------
+
+function classifySection(header: string, body: string): { tag: SectionTag; reason: string } {
+  const h = header.toLowerCase();
+
+  // Check STRIP first (more specific)
+  for (const pattern of STRIP_HEADERS) {
+    if (pattern.test(h)) return { tag: "strip", reason: `strip-header: ${pattern.source.slice(0, 40)}` };
+  }
+
+  // Check inline strip patterns in body
+  const strippableLines = body.split("\n").filter((line) =>
+    STRIP_INLINE_PATTERNS.some((p) => p.test(line))
+  );
+  if (strippableLines.length > 0 && strippableLines.length >= body.split("\n").length * 0.7) {
+    return { tag: "strip", reason: "strip-inline: majority of lines are boilerplate" };
+  }
+
+  // Check KEEP
+  for (const pattern of KEEP_HEADERS) {
+    if (pattern.test(h)) return { tag: "keep", reason: `keep-header: ${pattern.source.slice(0, 40)}` };
+  }
+
+  // Meta signals (no header — first section is usually job summary)
+  if (!header && body.length > 0) return { tag: "keep", reason: "keep: opening paragraph (no header)" };
+
+  return { tag: "unknown", reason: "unknown: no matching rule" };
+}
+
+// ---------------------------------------------------------------------------
+// Inline noise stripper
+// ---------------------------------------------------------------------------
+
+function stripInlineNoise(text: string): string {
+  return text
+    .split("\n")
+    .filter((line) => {
+      const t = line.trim();
+      if (!t) return true; // preserve blank lines
+      return !STRIP_INLINE_PATTERNS.some((p) => p.test(t));
+    })
+    .join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Metadata extractor
+// ---------------------------------------------------------------------------
+
+function extractMeta(text: string, titleHint?: string): JobMeta {
+  const meta: JobMeta = {};
+
+  if (titleHint) meta.title = titleHint;
+
+  const salaryMatch = text.match(SALARY_PATTERN);
+  if (salaryMatch) meta.salary = salaryMatch[0];
+
+  const typeMatch = text.match(JOB_TYPE_PATTERN);
+  if (typeMatch) meta.jobType = typeMatch[1].toLowerCase();
+
+  const remoteMatch = text.match(REMOTE_PATTERN);
+  if (remoteMatch) {
+    const r = remoteMatch[1].toLowerCase();
+    meta.remote = /remote|wfh/.test(r);
+  }
+
+  // Location: "Location: City, State" or "Remote - City, State"
+  const locationMatch = text.match(/(?:location|based\s+in|office)\s*:?\s*([^\n,]{3,60})/i);
+  if (locationMatch) meta.location = locationMatch[1].trim();
+
+  // Department
+  const deptMatch = text.match(/(?:department|team|division)\s*:?\s*([^\n]{3,50})/i);
+  if (deptMatch) meta.department = deptMatch[1].trim();
+
+  return meta;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a raw job description text into clean, AI-ready content.
+ *
+ * Strips: benefits, EEO statements, apply instructions, company marketing,
+ *         salary ranges, disclaimers, agency notices.
+ *
+ * Keeps: responsibilities, requirements, qualifications, skills, tech stack,
+ *        role overview, team context.
+ *
+ * @param rawText   Raw extracted text (from Cheerio or ATS API)
+ * @param titleHint Page title or ATS-provided title
+ */
+export function parseJobDescription(rawText: string, titleHint?: string): JobParseResult {
+  const meta = extractMeta(rawText, titleHint);
+  const rawSections = splitIntoSections(rawText);
+
+  const sections: ParsedSection[] = rawSections.map(({ header, body }) => {
+    const { tag, reason } = classifySection(header, body);
+    return { header, body, tag, reason };
+  });
+
+  // If no sections were KEEP-tagged, treat all unknown sections as keep
+  // (better to over-include than return empty for an unrecognized format)
+  const hasKeep = sections.some((s) => s.tag === "keep");
+
+  const keepSections = sections.filter((s) =>
+    s.tag === "keep" || (!hasKeep && s.tag === "unknown")
+  );
+
+  // Reconstruct clean text from keep sections
+  const cleanParts = keepSections.map((s) => {
+    const header = s.header ? `\n${s.header}\n` : "";
+    const body = stripInlineNoise(s.body);
+    return `${header}${body}`.trim();
+  });
+
+  const cleanDescription = cleanParts.filter(Boolean).join("\n\n").trim();
+
+  // Calculate stripped chars
+  const strippedSections = sections.filter((s) => s.tag === "strip");
+  const strippedChars = strippedSections.reduce((acc, s) => acc + s.body.length, 0);
+
+  // Quality check
+  const isJobDescription =
+    cleanDescription.length >= 150 &&
+    /\b(experience|requirements?|qualifications?|responsibilities|skills?|role|position)\b/i.test(cleanDescription);
+
+  return { cleanDescription, meta, sections, strippedChars, isJobDescription };
+}
+
+/**
+ * Convenience: parse and return just the clean text.
+ * Returns the original text if parsing produces empty output (safe fallback).
+ */
+export function cleanJobText(rawText: string, titleHint?: string): string {
+  if (!rawText || rawText.length < 100) return rawText;
+  const result = parseJobDescription(rawText, titleHint);
+  // If parser stripped too aggressively (e.g. unusual format), return original
+  if (result.cleanDescription.length < 150 && rawText.length >= 300) {
+    console.warn(`[job-parser] Parser output too short (${result.cleanDescription.length} chars), using original`);
+    return rawText;
+  }
+  return result.cleanDescription || rawText;
+}

--- a/supabase/functions/scrape-url/index.ts
+++ b/supabase/functions/scrape-url/index.ts
@@ -1,36 +1,41 @@
 /**
- * scrape-url — Supabase Edge Function (Deno)
+ * scrape-url — Adaptive Scraping Agent (Supabase Edge Function, Deno)
  *
- * Extraction pipeline (in priority order):
+ * An agent that gets smarter on every run by:
  *
- *  1. ATS JSON APIs — for JS-rendered boards with free public APIs:
- *       Greenhouse     → boards-api.greenhouse.io     (no auth)
- *       Lever          → api.lever.co                 (no auth)
- *       SmartRecruiters→ api.smartrecruiters.com      (no auth)
- *       Breezy HR      → {company}.breezy.hr/json/    (no auth)
- *       Ashby          → __NEXT_DATA__ SSR extraction
+ *  1. Reading the domain_extraction_hints table to see what worked before
+ *  2. Trying strategies in priority order (winners first)
+ *  3. Writing outcomes back so future runs skip failed strategies
  *
- *  2. Login-wall detection — sites that require auth (server-side scraping
- *     is technically impossible for these):
- *       LinkedIn, Indeed, Glassdoor, ZipRecruiter, Monster, Facebook,
- *       Upwork, Fiverr, FlexJobs, Handshake, WayUp,
- *       Workday, iCIMS, Taleo (IP-block cloud servers)
- *       → Returns a specific, helpful message per site
+ * Extraction strategies (tried in adaptive order):
+ *   A) ATS JSON APIs        — Greenhouse, Lever, SmartRecruiters, Breezy HR, Ashby
+ *   B) HTML fetch + Cheerio — Chrome 124 UA with 403-retry fallback
  *
- *  3. Direct HTML fetch → Cheerio DOM extraction
- *       Attempt A: Chrome 124 headers (full Sec-Fetch-* set)
- *       Attempt B: Minimal headers (WAF bypass on 403/429)
+ * Post-processing:
+ *   • extractJobBlock()     — Lovable's proven section isolation
+ *   • cleanJobMarkdown()    — Lovable's noise-pattern filtering
+ *   • parseJobDescription() — Section-aware parser strips benefits, EEO,
+ *                             apply instructions, company marketing so the
+ *                             AI analysis engine only receives skills-relevant content
  *
- *  4. Post-processing (Lovable pipeline, preserved):
- *       extractJobBlock → cleanJobMarkdown → quality gate
+ * Login-wall / IP-block detection:
+ *   Recognized per-site with helpful copy-paste tips (LinkedIn, Indeed, etc.)
+ *   Stored in the learning DB so repeat visits skip the attempt immediately.
  *
- * Security: SSRF protection, 20 req/min/user, 15s timeout
+ * Security: SSRF protection, 20 req/min/user, 15s per-attempt timeout
  */
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { checkRateLimit } from "../_shared/rate-limit.ts";
 import { validatePublicUrl } from "../_shared/validate-url.ts";
 import { extractWithCheerio } from "../_shared/cheerio-fallback.ts";
+import { cleanJobText } from "../_shared/job-parser.ts";
+import {
+  domainKey,
+  getDomainHint,
+  recordOutcome,
+  rankedStrategies,
+} from "../_shared/extraction-cache.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -62,204 +67,167 @@ const HEADERS_MINIMAL: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
-// Login-wall / IP-block detection
-// Sites where server-side scraping is technically impossible.
-// Returns a site-specific helpful message.
+// Login-wall / IP-block registry
 // ---------------------------------------------------------------------------
 
 interface LoginWallEntry {
   pattern: RegExp;
   name: string;
   reason: "login" | "ip-block";
-  tip?: string;
+  tip: string;
 }
 
 const LOGIN_WALL_SITES: LoginWallEntry[] = [
-  // Login-required job boards
-  { pattern: /linkedin\.com/i,         name: "LinkedIn",       reason: "login",    tip: "Open the job, click 'See more' to expand, then copy the full description." },
-  { pattern: /indeed\.com/i,           name: "Indeed",         reason: "login",    tip: "Open the job in your browser and copy the description from the page." },
-  { pattern: /glassdoor\.com/i,        name: "Glassdoor",      reason: "login",    tip: "Sign in to Glassdoor, open the job, and copy the description." },
-  { pattern: /ziprecruiter\.com/i,     name: "ZipRecruiter",   reason: "login",    tip: "Open the job in your browser and copy the description." },
-  { pattern: /monster\.com/i,          name: "Monster",        reason: "login",    tip: "Open the job in your browser and copy the description." },
-  { pattern: /facebook\.com\/jobs/i,   name: "Facebook Jobs",  reason: "login",    tip: "Open Facebook, find the job posting, and copy the description." },
-  { pattern: /upwork\.com/i,           name: "Upwork",         reason: "login",    tip: "Sign in to Upwork, open the job, and copy the description." },
-  { pattern: /fiverr\.com/i,           name: "Fiverr",         reason: "login",    tip: "Open the listing in your browser and copy the description." },
-  { pattern: /flexjobs\.com/i,         name: "FlexJobs",       reason: "login",    tip: "Sign in to FlexJobs, open the job, and copy the description." },
-  { pattern: /joinhandshake\.com/i,    name: "Handshake",      reason: "login",    tip: "Sign in to Handshake, open the job, and copy the description." },
-  { pattern: /wayup\.com/i,            name: "WayUp",          reason: "login",    tip: "Open the job in your browser and copy the description." },
-  { pattern: /careerbuilder\.com/i,    name: "CareerBuilder",  reason: "login" },
-  // IP-blocked ATS platforms
-  { pattern: /myworkdayjobs\.com/i,    name: "Workday",        reason: "ip-block", tip: "Copy the job description text from the page and paste it below." },
-  { pattern: /icims\.com/i,            name: "iCIMS",          reason: "ip-block", tip: "Copy the job description text from the page and paste it below." },
-  { pattern: /taleo\.net/i,            name: "Taleo",          reason: "ip-block", tip: "Copy the job description text from the page and paste it below." },
+  { pattern: /linkedin\.com/i,       name: "LinkedIn",       reason: "login",    tip: "Open the job, click 'See more' to expand the description, then copy and paste it below." },
+  { pattern: /indeed\.com/i,         name: "Indeed",         reason: "login",    tip: "Open the job in your browser and copy the full description from the page." },
+  { pattern: /glassdoor\.com/i,      name: "Glassdoor",      reason: "login",    tip: "Sign in to Glassdoor, open the job, and copy the description." },
+  { pattern: /ziprecruiter\.com/i,   name: "ZipRecruiter",   reason: "login",    tip: "Open the job in your browser and copy the description." },
+  { pattern: /monster\.com/i,        name: "Monster",        reason: "login",    tip: "Open the job in your browser and copy the description." },
+  { pattern: /facebook\.com\/jobs/i, name: "Facebook Jobs",  reason: "login",    tip: "Open the job on Facebook and copy the description." },
+  { pattern: /upwork\.com/i,         name: "Upwork",         reason: "login",    tip: "Sign in to Upwork, open the job, and copy the description." },
+  { pattern: /fiverr\.com/i,         name: "Fiverr",         reason: "login",    tip: "Open the listing in your browser and copy the description." },
+  { pattern: /flexjobs\.com/i,       name: "FlexJobs",       reason: "login",    tip: "Sign in to FlexJobs, open the job, and copy the description." },
+  { pattern: /joinhandshake\.com/i,  name: "Handshake",      reason: "login",    tip: "Sign in to Handshake, open the job, and copy the description." },
+  { pattern: /wayup\.com/i,          name: "WayUp",          reason: "login",    tip: "Open the job in your browser and copy the description." },
+  { pattern: /myworkdayjobs\.com/i,  name: "Workday",        reason: "ip-block", tip: "Open the job in your browser, copy the job description section, and paste it below." },
+  { pattern: /icims\.com/i,          name: "iCIMS",          reason: "ip-block", tip: "Open the job in your browser and copy the description." },
+  { pattern: /taleo\.net/i,          name: "Taleo",          reason: "ip-block", tip: "Open the job in your browser and copy the description." },
 ];
 
 function getLoginWallMessage(url: string): string | null {
   for (const site of LOGIN_WALL_SITES) {
     if (site.pattern.test(url)) {
-      const base = site.reason === "login"
-        ? `${site.name} requires sign-in to view job descriptions — automated access isn't possible.`
-        : `${site.name} blocks automated server access.`;
-      const tip = site.tip ?? "Open the job in your browser, copy the description, and paste it below.";
-      return `${base} ${tip}`;
+      const why = site.reason === "login"
+        ? `${site.name} requires sign-in — automated access is not possible.`
+        : `${site.name} blocks server-side access.`;
+      return `${why} ${site.tip}`;
     }
   }
   return null;
 }
 
-// ---------------------------------------------------------------------------
-// ATS JSON APIs — free, no auth required
-// ---------------------------------------------------------------------------
-
-interface AtsResult {
-  ok: boolean;
-  text?: string;
-  title?: string;
-  error?: string;
+function isKnownLoginWall(url: string): boolean {
+  return LOGIN_WALL_SITES.some((s) => s.pattern.test(url));
 }
 
-/** Greenhouse: boards-api.greenhouse.io/v1/boards/{board}/jobs/{id} */
+// ---------------------------------------------------------------------------
+// ATS JSON APIs
+// ---------------------------------------------------------------------------
+
+interface AtsResult { ok: boolean; text?: string; title?: string; strategy?: string; error?: string; }
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ").replace(/&amp;/g, "&").replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">").replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+    .replace(/[ \t]+/g, " ").replace(/\n{3,}/g, "\n\n").trim();
+}
+
 async function fetchGreenhouse(url: string): Promise<AtsResult | null> {
-  let board: string, jobId: string;
   let m = url.match(/boards\.greenhouse\.io\/([^/?#]+)\/jobs\/(\d+)/i);
-  if (m) { [, board, jobId] = m; }
-  else {
-    m = url.match(/([^./]+)\.greenhouse\.io\/jobs\/(\d+)/i);
-    if (m) { [, board, jobId] = m; } else return null;
-  }
-  const apiUrl = `https://boards-api.greenhouse.io/v1/boards/${board}/jobs/${jobId}`;
-  console.log(`[scrape-url] Greenhouse API: ${apiUrl}`);
+  if (!m) m = url.match(/([^./]+)\.greenhouse\.io\/jobs\/(\d+)/i);
+  if (!m) return null;
+  const [, board, jobId] = m;
   try {
-    const res = await fetch(apiUrl, { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000) });
-    if (!res.ok) return { ok: false, error: `Greenhouse API ${res.status}` };
-    const data = await res.json();
-    const title: string = data.title ?? "";
-    const text = stripHtml(data.content ?? "");
-    const location = data.location?.name ?? "";
-    const dept = data.departments?.[0]?.name ?? "";
+    const r = await fetch(`https://boards-api.greenhouse.io/v1/boards/${board}/jobs/${jobId}`, {
+      headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000),
+    });
+    if (!r.ok) return { ok: false, strategy: "greenhouse-api", error: `API ${r.status}` };
+    const d = await r.json();
+    const text = stripHtml(d.content ?? "");
+    const location = d.location?.name ?? "";
+    const dept = d.departments?.[0]?.name ?? "";
     const meta = [dept && `Department: ${dept}`, location && `Location: ${location}`].filter(Boolean).join("\n");
-    return { ok: true, text: meta ? `${text}\n\n${meta}` : text, title };
-  } catch (e) { return { ok: false, error: String(e) }; }
+    return { ok: true, text: meta ? `${text}\n\n${meta}` : text, title: d.title ?? "", strategy: "greenhouse-api" };
+  } catch (e) { return { ok: false, strategy: "greenhouse-api", error: String(e) }; }
 }
 
-/** Lever: api.lever.co/v0/postings/{company}/{job_id} */
 async function fetchLever(url: string): Promise<AtsResult | null> {
   const m = url.match(/jobs\.lever\.co\/([^/?#]+)\/([a-f0-9-]{36})/i);
   if (!m) return null;
   const [, company, jobId] = m;
-  const apiUrl = `https://api.lever.co/v0/postings/${company}/${jobId}`;
-  console.log(`[scrape-url] Lever API: ${apiUrl}`);
   try {
-    const res = await fetch(apiUrl, { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000) });
-    if (!res.ok) return { ok: false, error: `Lever API ${res.status}` };
-    const data = await res.json();
-    const title: string = data.text ?? "";
-    const desc = data.descriptionPlain ?? stripHtml(data.description ?? "");
-    const additional = stripHtml(data.additional ?? data.additionalPlain ?? "");
-    const lists = (data.lists ?? [])
-      .map((l: any) => `${l.text}:\n${stripHtml(l.content ?? "").replace(/\n/g, "\n- ")}`)
-      .join("\n\n");
+    const r = await fetch(`https://api.lever.co/v0/postings/${company}/${jobId}`, {
+      headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000),
+    });
+    if (!r.ok) return { ok: false, strategy: "lever-api", error: `API ${r.status}` };
+    const d = await r.json();
+    const desc = d.descriptionPlain ?? stripHtml(d.description ?? "");
+    const lists = (d.lists ?? []).map((l: any) => `${l.text}:\n${stripHtml(l.content ?? "")}`).join("\n\n");
+    const additional = stripHtml(d.additional ?? "");
     const meta = [
-      data.categories?.location && `Location: ${data.categories.location}`,
-      data.categories?.team && `Team: ${data.categories.team}`,
-      data.categories?.commitment && `Type: ${data.categories.commitment}`,
+      d.categories?.location && `Location: ${d.categories.location}`,
+      d.categories?.team && `Team: ${d.categories.team}`,
+      d.categories?.commitment && `Type: ${d.categories.commitment}`,
     ].filter(Boolean).join("\n");
-    return { ok: true, text: [desc, lists, additional, meta].filter(Boolean).join("\n\n").trim(), title };
-  } catch (e) { return { ok: false, error: String(e) }; }
+    return { ok: true, text: [desc, lists, additional, meta].filter(Boolean).join("\n\n").trim(), title: d.text ?? "", strategy: "lever-api" };
+  } catch (e) { return { ok: false, strategy: "lever-api", error: String(e) }; }
 }
 
-/** SmartRecruiters: api.smartrecruiters.com/v1/companies/{company}/postings/{id} */
 async function fetchSmartRecruiters(url: string): Promise<AtsResult | null> {
-  // URL patterns: jobs.smartrecruiters.com/{company}/{id} or smartrecruiters.com/job/{company}/{id}
-  let m = url.match(/(?:jobs\.)?smartrecruiters\.com\/([^/?#]+)\/([^/?#]+)/i);
+  const m = url.match(/(?:jobs\.)?smartrecruiters\.com\/([^/?#]+)\/([^/?#]+)/i);
   if (!m) return null;
   const [, company, jobId] = m;
   if (!jobId || jobId.length < 5) return null;
-  const apiUrl = `https://api.smartrecruiters.com/v1/companies/${company}/postings/${jobId}`;
-  console.log(`[scrape-url] SmartRecruiters API: ${apiUrl}`);
   try {
-    const res = await fetch(apiUrl, { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000) });
-    if (!res.ok) return { ok: false, error: `SmartRecruiters API ${res.status}` };
-    const data = await res.json();
-    const title: string = data.name ?? "";
-    const sections = (data.jobAd?.sections ?? {});
+    const r = await fetch(`https://api.smartrecruiters.com/v1/companies/${company}/postings/${jobId}`, {
+      headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000),
+    });
+    if (!r.ok) return { ok: false, strategy: "smartrecruiters-api", error: `API ${r.status}` };
+    const d = await r.json();
+    const sections = d.jobAd?.sections ?? {};
     const parts = [
       sections.companyDescription?.text && stripHtml(sections.companyDescription.text),
       sections.jobDescription?.text && stripHtml(sections.jobDescription.text),
       sections.qualifications?.text && stripHtml(sections.qualifications.text),
       sections.additionalInformation?.text && stripHtml(sections.additionalInformation.text),
     ].filter(Boolean);
-    const location = data.location?.city ?? data.location?.country ?? "";
-    const dept = data.department?.label ?? "";
-    const meta = [dept && `Department: ${dept}`, location && `Location: ${location}`].filter(Boolean).join("\n");
-    return { ok: true, text: [...parts, meta].filter(Boolean).join("\n\n").trim(), title };
-  } catch (e) { return { ok: false, error: String(e) }; }
+    const loc = d.location?.city ?? d.location?.country ?? "";
+    const dept = d.department?.label ?? "";
+    const meta = [dept && `Department: ${dept}`, loc && `Location: ${loc}`].filter(Boolean).join("\n");
+    return { ok: true, text: [...parts, meta].filter(Boolean).join("\n\n").trim(), title: d.name ?? "", strategy: "smartrecruiters-api" };
+  } catch (e) { return { ok: false, strategy: "smartrecruiters-api", error: String(e) }; }
 }
 
-/** Breezy HR: {company}.breezy.hr — uses /json/ API endpoint */
 async function fetchBreezyHR(url: string): Promise<AtsResult | null> {
   const m = url.match(/([^.]+)\.breezy\.hr(?:\/p\/([^/?#]+))?/i);
-  if (!m) return null;
+  if (!m || !m[2]) return null;
   const [, company, slug] = m;
-  if (!slug) return null;
-  const apiUrl = `https://${company}.breezy.hr/json/${slug}`;
-  console.log(`[scrape-url] Breezy HR API: ${apiUrl}`);
   try {
-    const res = await fetch(apiUrl, { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000) });
-    if (!res.ok) return { ok: false, error: `Breezy API ${res.status}` };
-    const data = await res.json();
-    const title: string = data.name ?? "";
-    const text = stripHtml(data.description ?? "");
-    const location = data.location?.name ?? "";
-    const dept = data.department?.name ?? "";
-    const meta = [dept && `Department: ${dept}`, location && `Location: ${location}`].filter(Boolean).join("\n");
-    return { ok: true, text: meta ? `${text}\n\n${meta}` : text, title };
-  } catch (e) { return { ok: false, error: String(e) }; }
+    const r = await fetch(`https://${company}.breezy.hr/json/${slug}`, {
+      headers: { Accept: "application/json" }, signal: AbortSignal.timeout(10_000),
+    });
+    if (!r.ok) return { ok: false, strategy: "breezy-api", error: `API ${r.status}` };
+    const d = await r.json();
+    const text = stripHtml(d.description ?? "");
+    const loc = d.location?.name ?? "";
+    const dept = d.department?.name ?? "";
+    const meta = [dept && `Department: ${dept}`, loc && `Location: ${loc}`].filter(Boolean).join("\n");
+    return { ok: true, text: meta ? `${text}\n\n${meta}` : text, title: d.name ?? "", strategy: "breezy-api" };
+  } catch (e) { return { ok: false, strategy: "breezy-api", error: String(e) }; }
 }
 
-/** Ashby — extracts job data from __NEXT_DATA__ embedded JSON */
 async function fetchAshby(url: string): Promise<AtsResult | null> {
   if (!/jobs\.ashbyhq\.com/i.test(url)) return null;
-  console.log(`[scrape-url] Ashby __NEXT_DATA__: ${url}`);
   try {
-    const res = await fetch(url, { headers: HEADERS_CHROME, signal: AbortSignal.timeout(12_000) });
-    if (!res.ok) return { ok: false, error: `Ashby ${res.status}` };
-    const html = await res.text();
+    const r = await fetch(url, { headers: HEADERS_CHROME, signal: AbortSignal.timeout(12_000) });
+    if (!r.ok) return { ok: false, strategy: "ashby-ssr", error: `HTTP ${r.status}` };
+    const html = await r.text();
     const m = html.match(/<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/i);
-    if (!m) return null;
+    if (!m) return { ok: false, strategy: "ashby-ssr", error: "no __NEXT_DATA__" };
     const json = JSON.parse(m[1]);
     const job = json?.props?.pageProps?.jobPosting ?? json?.props?.pageProps?.posting ?? null;
-    if (!job) return null;
-    const title: string = job.title ?? "";
-    const text = stripHtml(job.descriptionHtml ?? job.content ?? "");
-    return { ok: true, text, title };
-  } catch (e) { return { ok: false, error: String(e) }; }
-}
-
-/** Route to the correct ATS API. Returns null → fall through to HTML fetch. */
-async function tryAtsApi(url: string): Promise<AtsResult | null> {
-  return (
-    await fetchGreenhouse(url) ??
-    await fetchLever(url) ??
-    await fetchSmartRecruiters(url) ??
-    await fetchBreezyHR(url) ??
-    await fetchAshby(url)
-  );
+    if (!job) return { ok: false, strategy: "ashby-ssr", error: "no job in __NEXT_DATA__" };
+    return { ok: true, text: stripHtml(job.descriptionHtml ?? job.content ?? ""), title: job.title ?? "", strategy: "ashby-ssr" };
+  } catch (e) { return { ok: false, strategy: "ashby-ssr", error: String(e) }; }
 }
 
 // ---------------------------------------------------------------------------
-// Generic HTML fetch (with 403 retry)
+// HTML fetch with 403 retry
 // ---------------------------------------------------------------------------
 
-interface FetchResult {
-  ok: boolean;
-  html?: string;
-  contentType?: string;
-  status?: number;
-  error?: string;
-}
-
-async function fetchWithFallback(url: string): Promise<FetchResult> {
+async function fetchHtml(url: string): Promise<{ ok: boolean; html?: string; contentType?: string; status?: number; error?: string }> {
   const go = (h: Record<string, string>) =>
     fetch(url, { headers: h, signal: AbortSignal.timeout(15_000), redirect: "follow" });
   try {
@@ -267,7 +235,6 @@ async function fetchWithFallback(url: string): Promise<FetchResult> {
     if (r.ok) return { ok: true, html: await r.text(), contentType: r.headers.get("content-type") ?? "", status: r.status };
     if (r.status === 403 || r.status === 429) {
       await r.body?.cancel();
-      console.log(`[scrape-url] ${r.status}, retrying minimal headers: ${url}`);
       const r2 = await go(HEADERS_MINIMAL);
       if (r2.ok) return { ok: true, html: await r2.text(), contentType: r2.headers.get("content-type") ?? "", status: r2.status };
       await r2.body?.cancel();
@@ -279,7 +246,7 @@ async function fetchWithFallback(url: string): Promise<FetchResult> {
 }
 
 // ---------------------------------------------------------------------------
-// Post-processing — Lovable's pipeline (preserved exactly)
+// Lovable's post-processing pipeline (preserved)
 // ---------------------------------------------------------------------------
 
 const NOISE_PATTERNS = [
@@ -346,21 +313,18 @@ function extractJobBlock(markdown: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Full processing pipeline
 // ---------------------------------------------------------------------------
 
-function stripHtml(html: string): string {
-  return html
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/[ \t]+/g, " ")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+/**
+ * Given raw extracted text, apply the full post-processing stack:
+ * Lovable's extractJobBlock + cleanJobMarkdown + smart job-parser.
+ */
+function processText(rawText: string, titleHint?: string): string {
+  const jobBlock = extractJobBlock(rawText);
+  const cleaned = cleanJobMarkdown(jobBlock);
+  // Final pass: section-aware parser strips benefits, EEO, apply instructions
+  return cleanJobText(cleaned, titleHint);
 }
 
 // ---------------------------------------------------------------------------
@@ -374,51 +338,138 @@ Deno.serve(async (req) => {
     // ── Auth ─────────────────────────────────────────────────────────────────
     const authHeader = req.headers.get("Authorization");
     if (!authHeader?.startsWith("Bearer ")) return res({ success: false, error: "Missing authorization header" }, 401);
-    const supabase = createClient(
+
+    const supabaseAnon = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
       Deno.env.get("SUPABASE_ANON_KEY") ?? "",
       { global: { headers: { Authorization: authHeader } } }
     );
-    const { data, error: authError } = await (supabase.auth as any).getClaims(authHeader.replace("Bearer ", ""));
+    const { data, error: authError } = await (supabaseAnon.auth as any).getClaims(authHeader.replace("Bearer ", ""));
     if (authError || !data?.claims) return res({ success: false, error: "Invalid or expired token" }, 401);
     const userId: string = data.claims.sub;
 
-    // ── Rate limit (20/min) ───────────────────────────────────────────────────
-    if (!checkRateLimit(`scrape-url:${userId}`, 20, 60_000)) return res({ success: false, error: "Too many requests – please slow down" }, 429);
+    // Admin client for cache reads/writes (service role bypasses RLS)
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    );
+
+    // ── Rate limit ────────────────────────────────────────────────────────────
+    if (!checkRateLimit(`scrape-url:${userId}`, 20, 60_000)) {
+      return res({ success: false, error: "Too many requests – please slow down" }, 429);
+    }
 
     // ── Validate URL ──────────────────────────────────────────────────────────
     const body = await req.json();
     const { url } = body;
     if (!url) return res({ success: false, error: "URL is required" }, 400);
+
     const validated = validatePublicUrl(url);
     if (!validated.ok) return res({ success: false, error: validated.error }, 400);
     const validUrl = validated.url;
+    const domain = domainKey(validUrl);
 
-    // ── Step 1: Login-wall check ──────────────────────────────────────────────
+    // ── Step 1: Login-wall fast-path ──────────────────────────────────────────
     const loginMsg = getLoginWallMessage(validUrl);
     if (loginMsg) {
+      // Record to DB so repeat visits are instant
+      await recordOutcome(supabaseAdmin, domain, {
+        success: false, strategy: "login-wall", notes: "login-wall detected at validation",
+      });
       return res({ success: false, extractionFailed: true, error: loginMsg });
     }
 
-    // ── Step 2: ATS JSON API ──────────────────────────────────────────────────
-    const atsResult = await tryAtsApi(validUrl);
-    if (atsResult?.ok && (atsResult.text?.length ?? 0) >= 100) {
-      const cleaned = cleanJobMarkdown(extractJobBlock(atsResult.text!));
-      if (cleaned.length >= 200) {
-        console.log(`[scrape-url] ATS API success (${cleaned.length} chars): ${validUrl}`);
-        return res({ success: true, markdown: cleaned.slice(0, 8_000), title: atsResult.title });
+    // ── Step 2: Read domain hint (adaptive learning) ───────────────────────────
+    const hint = await getDomainHint(supabaseAdmin, domain);
+    if (hint) {
+      console.log(`[scrape-url] Domain hint for ${domain}: strategy=${hint.bestStrategy}, success=${hint.successCount}, fail=${hint.failureCount}`);
+    }
+
+    // If the domain was previously found to be login-wall or ip-blocked, short-circuit
+    if (hint?.bestStrategy === "login-wall" || hint?.bestStrategy === "ip-blocked") {
+      return res({
+        success: false, extractionFailed: true,
+        error: `This site has previously blocked automated access. Please copy the job description and paste it below.`,
+      });
+    }
+
+    // ── Step 3: ATS JSON APIs ─────────────────────────────────────────────────
+    const atsApis: Array<() => Promise<AtsResult | null>> = [
+      () => fetchGreenhouse(validUrl),
+      () => fetchLever(validUrl),
+      () => fetchSmartRecruiters(validUrl),
+      () => fetchBreezyHR(validUrl),
+      () => fetchAshby(validUrl),
+    ];
+
+    // If we know this domain works with a specific ATS API, try it first
+    const preferredStrategy = hint?.bestStrategy;
+    const strategyOrder = rankedStrategies(hint, [
+      "greenhouse-api", "lever-api", "smartrecruiters-api", "breezy-api", "ashby-ssr", "html-fetch",
+    ]);
+
+    let atsText: string | null = null;
+    let atsTitle: string | null = null;
+    let atsStrategy: string | null = null;
+
+    // Try ATS APIs in ranked order
+    for (const strategyName of strategyOrder) {
+      if (strategyName === "html-fetch") break; // handled separately below
+
+      const apiFn = atsApis.find((fn) => {
+        const testResult = fn.toString();
+        return testResult.includes(strategyName.split("-")[0]);
+      });
+
+      // Run the matching API
+      let result: AtsResult | null = null;
+      if (strategyName === "greenhouse-api") result = await fetchGreenhouse(validUrl);
+      else if (strategyName === "lever-api") result = await fetchLever(validUrl);
+      else if (strategyName === "smartrecruiters-api") result = await fetchSmartRecruiters(validUrl);
+      else if (strategyName === "breezy-api") result = await fetchBreezyHR(validUrl);
+      else if (strategyName === "ashby-ssr") result = await fetchAshby(validUrl);
+
+      if (result === null) continue; // this ATS API doesn't match the URL pattern
+
+      if (result.ok && (result.text?.length ?? 0) >= 100) {
+        atsText = result.text!;
+        atsTitle = result.title ?? null;
+        atsStrategy = result.strategy ?? strategyName;
+        break;
       }
     }
 
-    // ── Step 3: HTML fetch + Cheerio ──────────────────────────────────────────
-    const fetched = await fetchWithFallback(validUrl);
-    if (!fetched.ok) {
-      if (fetched.error) {
-        const isTimeout = /timeout|abort/i.test(fetched.error);
-        return res({ success: false, extractionFailed: true, error: isTimeout ? "The page took too long to load. Please paste the job description manually." : "Unable to reach the page. Please paste the job description manually." });
+    if (atsText && atsText.length >= 100) {
+      const processed = processText(atsText, atsTitle ?? undefined);
+      if (processed.length >= 150) {
+        await recordOutcome(supabaseAdmin, domain, { success: true, strategy: atsStrategy! });
+        console.log(`[scrape-url] ATS API success via ${atsStrategy} (${processed.length} chars): ${validUrl}`);
+        return res({ success: true, markdown: processed.slice(0, 8_000), title: atsTitle ?? "" });
       }
-      // One last login-wall check on the actual HTTP status
-      return res({ success: false, extractionFailed: true, error: `Could not load the page (HTTP ${fetched.status}). Please paste the job description manually.` });
+    }
+
+    // ── Step 4: HTML fetch + Cheerio ──────────────────────────────────────────
+    const fetched = await fetchHtml(validUrl);
+
+    if (!fetched.ok) {
+      const isTimeout = /timeout|abort/i.test(fetched.error ?? "");
+      const isIpBlock = fetched.status === 403;
+
+      // Learn from failure
+      await recordOutcome(supabaseAdmin, domain, {
+        success: false,
+        strategy: isIpBlock ? "ip-blocked" : "html-fetch",
+        notes: isIpBlock ? `HTTP 403 — likely IP-blocked` : `HTTP ${fetched.status ?? "error"}: ${fetched.error ?? ""}`,
+      });
+
+      return res({
+        success: false, extractionFailed: true,
+        error: isTimeout
+          ? "The page took too long to load. Please paste the job description manually."
+          : isIpBlock
+          ? "This site is blocking automated access. Please copy the job description from your browser and paste it below."
+          : "Unable to reach the page. Please paste the job description manually.",
+      });
     }
 
     const { html = "", contentType = "" } = fetched;
@@ -427,20 +478,32 @@ Deno.serve(async (req) => {
     }
 
     const extraction = await extractWithCheerio(html, validUrl);
-    const jobBlock = extractJobBlock(extraction.text ?? "");
-    const cleaned = cleanJobMarkdown(jobBlock);
+    const rawText = extraction.text ?? "";
     const pageTitle = extraction.title ?? "";
 
-    if (cleaned.length < 300) {
-      return res({ success: false, extractionFailed: true, error: "We couldn't extract enough content from this URL. Please paste the job description manually.", partialText: cleaned || undefined });
+    const processed = processText(rawText, pageTitle || undefined);
+
+    if (processed.length < 300) {
+      await recordOutcome(supabaseAdmin, domain, { success: false, strategy: "html-fetch", notes: `too short: ${processed.length} chars after processing` });
+      return res({ success: false, extractionFailed: true, error: "We couldn't extract enough content from this URL. Please paste the job description manually.", partialText: processed || undefined });
     }
 
-    const hasJobSignals = /\b(experience|requirements?|qualifications?|responsibilities|skills?|salary|compensation|benefits?|about\s*(the\s*)?(role|position|company)|what\s*you)\b/i.test(cleaned);
+    const hasJobSignals = /\b(experience|requirements?|qualifications?|responsibilities|skills?|salary|compensation|benefits?|about\s*(the\s*)?(role|position|company)|what\s*you)\b/i.test(processed);
     if (!hasJobSignals) {
-      return res({ success: false, extractionFailed: true, error: "The extracted content doesn't appear to be a job description. Please paste it manually.", partialText: cleaned.slice(0, 500) || undefined });
+      await recordOutcome(supabaseAdmin, domain, { success: false, strategy: "html-fetch", notes: "no job signals in extracted text" });
+      return res({ success: false, extractionFailed: true, error: "The extracted content doesn't appear to be a job description. Please paste it manually.", partialText: processed.slice(0, 500) || undefined });
     }
 
-    return res({ success: true, markdown: cleaned.slice(0, 8_000), title: pageTitle });
+    // Learn the successful selector from Cheerio extraction
+    const successfulSelector = extraction.strategy ?? "html-fetch";
+    await recordOutcome(supabaseAdmin, domain, {
+      success: true,
+      strategy: successfulSelector.startsWith("ats:") || successfulSelector.startsWith("generic:") ? `cheerio:${successfulSelector}` : "html-fetch",
+      selector: successfulSelector,
+    });
+
+    console.log(`[scrape-url] HTML success via ${successfulSelector} (${processed.length} chars): ${validUrl}`);
+    return res({ success: true, markdown: processed.slice(0, 8_000), title: pageTitle });
 
   } catch (error) {
     console.error("[scrape-url] Unhandled error:", error);

--- a/supabase/migrations/20260430_domain_extraction_hints.sql
+++ b/supabase/migrations/20260430_domain_extraction_hints.sql
@@ -1,0 +1,84 @@
+-- ============================================================================
+-- domain_extraction_hints
+--
+-- Persistent learning table for the adaptive scrape-url agent.
+-- Each row represents one domain and records which extraction strategy
+-- worked best, how many times, and any learned CSS selectors.
+--
+-- The edge function reads this on each request to skip failed strategies
+-- and try winners first. It writes back outcomes after every extraction.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS domain_extraction_hints (
+  id             uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  domain         text        NOT NULL,
+
+  -- Best strategy that succeeded most recently
+  -- Values: 'greenhouse-api' | 'lever-api' | 'smartrecruiters-api' |
+  --         'breezy-api' | 'ashby-ssr' | 'cheerio:{selector}' |
+  --         'login-wall' | 'ip-blocked' | 'html-fetch'
+  best_strategy  text,
+
+  -- Learned CSS selector (if cheerio strategy)
+  best_selector  text,
+
+  -- Outcome counters
+  success_count  integer     NOT NULL DEFAULT 0,
+  failure_count  integer     NOT NULL DEFAULT 0,
+
+  -- Timestamps
+  last_success_at  timestamptz,
+  last_failure_at  timestamptz,
+  last_seen_at     timestamptz NOT NULL DEFAULT now(),
+
+  -- Freeform notes from the agent (e.g. "js-rendered", "requires-login")
+  notes          text,
+
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+-- One row per domain
+CREATE UNIQUE INDEX IF NOT EXISTS domain_extraction_hints_domain_idx
+  ON domain_extraction_hints(domain);
+
+-- Fast lookups
+CREATE INDEX IF NOT EXISTS domain_extraction_hints_strategy_idx
+  ON domain_extraction_hints(best_strategy);
+
+-- Updated-at trigger
+CREATE OR REPLACE FUNCTION update_domain_extraction_hints_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_domain_extraction_hints_updated_at ON domain_extraction_hints;
+CREATE TRIGGER trg_domain_extraction_hints_updated_at
+  BEFORE UPDATE ON domain_extraction_hints
+  FOR EACH ROW EXECUTE FUNCTION update_domain_extraction_hints_updated_at();
+
+-- RLS: edge functions use service role key (bypasses RLS)
+-- Admins can view via dashboard; users cannot access this table.
+ALTER TABLE domain_extraction_hints ENABLE ROW LEVEL SECURITY;
+
+-- Allow service role full access (edge functions)
+CREATE POLICY "service_role_full_access" ON domain_extraction_hints
+  TO service_role USING (true) WITH CHECK (true);
+
+-- Allow authenticated admins to read (for observability dashboard)
+CREATE POLICY "admin_read" ON domain_extraction_hints
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+        AND profiles.role = 'support_agent'
+    )
+  );
+
+COMMENT ON TABLE domain_extraction_hints IS
+  'Adaptive learning table for scrape-url. Tracks which strategy + selector '
+  'succeeded for each domain so the agent prioritizes winners on future runs.';

--- a/supabase/migrations/20260430_extraction_cache_rpcs.sql
+++ b/supabase/migrations/20260430_extraction_cache_rpcs.sql
@@ -1,0 +1,41 @@
+-- ============================================================================
+-- Helper RPCs for the adaptive extraction cache
+-- These are called by the edge function after each scrape attempt.
+-- Using RPCs guarantees atomic counter increments without race conditions.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION increment_extraction_success(p_domain text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO domain_extraction_hints (domain, success_count, failure_count)
+    VALUES (p_domain, 1, 0)
+  ON CONFLICT (domain)
+  DO UPDATE SET
+    success_count  = domain_extraction_hints.success_count + 1,
+    last_seen_at   = now(),
+    updated_at     = now();
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION increment_extraction_failure(p_domain text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO domain_extraction_hints (domain, success_count, failure_count)
+    VALUES (p_domain, 0, 1)
+  ON CONFLICT (domain)
+  DO UPDATE SET
+    failure_count  = domain_extraction_hints.failure_count + 1,
+    last_seen_at   = now(),
+    updated_at     = now();
+END;
+$$;
+
+-- Grant to service role (used by edge functions)
+GRANT EXECUTE ON FUNCTION increment_extraction_success(text) TO service_role;
+GRANT EXECUTE ON FUNCTION increment_extraction_failure(text) TO service_role;


### PR DESCRIPTION
## Adaptive Learning Agent

The scrape-url function now learns from every run:

- `domain_extraction_hints` table — one row per domain, stores best strategy, CSS selector, success/failure counts
- On each request: reads the hint and **tries the proven winner first**
- After each request: writes outcome back (async, never blocks the response)
- Login-wall domains cached so repeat visits return the helpful message instantly, skipping any fetch attempt

## Smart Job Parser (`job-parser.ts`)

Section-aware parser that tags every part of a job description:

| Tag | What | Why |
|---|---|---|
| **KEEP** | Responsibilities, requirements, qualifications, skills, tech stack | AI needs this |
| **STRIP** | Benefits, EEO statements, apply instructions, company marketing, legal disclaimers | Inflates skill extraction |
| **META** | Title, location, salary, job type | Preserved separately |

Safe fallback: if parser strips too aggressively, it returns the original text.

## Result

- AI analysis engine only receives skills-relevant content
- Benefits and boilerplate can no longer inflate the skill gap analysis
- Each domain gets faster and more accurate over time