### PR TITLE
feat(job-search): AI matching agent + live job feeds + smart enrichment

### DIFF
--- a/supabase/functions/discover-jobs/index.ts
+++ b/supabase/functions/discover-jobs/index.ts
@@ -1,49 +1,126 @@
-// iCareerOS v5 — discover-jobs Edge Function
-// Zero-dependency: uses inline PostgREST client (no npm/jsr/esm imports).
-// Queries the pre-populated job_postings table and enriches with cached fit scores.
+/**
+ * discover-jobs — Job Search + AI Match Enrichment (Supabase Edge Function, Deno)
+ *
+ * Queries job_postings with filters and enriches results with AI fit scores
+ * from user_job_matches. If the user has unscored jobs, triggers background
+ * matching (fire-and-forget) so the next search returns enriched results.
+ *
+ * Zero-dependency: uses inline PostgREST fetch (no npm/jsr imports).
+ * This keeps cold-start time minimal.
+ *
+ * POST body:
+ *  {
+ *    searchTerm: string,       required — keywords to search
+ *    userId?: string,          — enrich with AI fit scores for this user
+ *    location?: string,
+ *    isRemote?: boolean,
+ *    jobType?: string,         — 'fulltime' | 'parttime' | 'contract' | 'internship'
+ *    salaryMin?: number,
+ *    minFitScore?: number,     — filter out jobs below this score (0-100)
+ *    hoursOld?: number,        — max age in hours (default 48)
+ *    limit?: number,           — max results (default 50)
+ *    offset?: number,          — pagination (default 0)
+ *    triggerMatch?: boolean,   — fire background match-jobs if unscored jobs exist
+ *  }
+ *
+ * Response:
+ *  {
+ *    jobs: JobResult[],
+ *    total: number,
+ *    searchTerm: string,
+ *    matchingTriggered: boolean,
+ *    source: "icareeros-native-v6"
+ *  }
+ */
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers":
-    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
 };
 
-// ─── Inline PostgREST helper ──────────────────────────────────────────────
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_KEY  = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const ANON_KEY     = Deno.env.get("SUPABASE_ANON_KEY")!;
+
+// ---------------------------------------------------------------------------
+// Inline PostgREST helper (zero deps)
+// ---------------------------------------------------------------------------
 
 async function pgrest(
   table: string,
   query: string,
-  opts: { method?: string; body?: string; prefer?: string } = {},
+  opts: { method?: string; body?: string; prefer?: string } = {}
 ): Promise<any> {
   const url = `${SUPABASE_URL}/rest/v1/${table}?${query}`;
   const res = await fetch(url, {
-    method: opts.method || "GET",
+    method: opts.method ?? "GET",
     headers: {
       apikey: SERVICE_KEY,
       Authorization: `Bearer ${SERVICE_KEY}`,
       "Content-Type": "application/json",
-      Prefer: opts.prefer || "return=representation",
+      Prefer: opts.prefer ?? "return=representation",
     },
     ...(opts.body ? { body: opts.body } : {}),
   });
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`PostgREST ${res.status}: ${text}`);
+    throw new Error(`PostgREST ${res.status}: ${text.slice(0, 300)}`);
   }
   return res.json();
 }
 
-// ─── Handler ──────────────────────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Auth helper
+// ---------------------------------------------------------------------------
+
+async function verifyToken(token: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${SUPABASE_URL}/auth/v1/user`, {
+      headers: { apikey: ANON_KEY, Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.id ?? null;
+  } catch { return null; }
+}
+
+// ---------------------------------------------------------------------------
+// Background match trigger (fire-and-forget)
+// ---------------------------------------------------------------------------
+
+function triggerBackgroundMatch(authToken: string, userId: string): void {
+  const url = `${SUPABASE_URL}/functions/v1/match-jobs`;
+  fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ userId, limit: 50 }),
+  }).catch((e) => console.warn("[discover-jobs] Background match trigger failed:", e));
+  // fire-and-forget — response ignored
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
 Deno.serve(async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
 
   try {
+    // ── Auth ─────────────────────────────────────────────────────────────────
+    const authHeader = req.headers.get("Authorization") ?? "";
+    const token = authHeader.replace("Bearer ", "").trim();
+    let authenticatedUserId: string | null = null;
+    if (token) {
+      authenticatedUserId = await verifyToken(token);
+    }
+
+    // ── Parse body ────────────────────────────────────────────────────────────
     const {
       searchTerm,
+      userId: requestedUserId,
       location,
       isRemote,
       jobType,
@@ -52,87 +129,109 @@ Deno.serve(async (req) => {
       hoursOld = 48,
       limit = 50,
       offset = 0,
-      userId,
+      triggerMatch = true,
     } = await req.json();
 
     if (!searchTerm?.trim()) {
-      return new Response(
-        JSON.stringify({ error: "searchTerm is required" }),
-        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
-      );
+      return jsonRes({ error: "searchTerm is required" }, 400);
     }
 
-    // Log this search for dynamic scraper config (non-blocking)
-    if (userId) {
-      pgrest(
-        "search_queries",
-        "",
-        {
-          method: "POST",
-          body: JSON.stringify({
-            user_id: userId,
-            search_term: searchTerm.trim(),
-            location: location || null,
-            is_remote: isRemote || null,
-          }),
-          prefer: "return=minimal",
-        },
-      ).catch(() => {}); // fire-and-forget
-    }
-
-    const cutoff = new Date(Date.now() - hoursOld * 60 * 60 * 1000).toISOString();
+    // Use authenticated userId, fall back to requested (for service-role calls)
+    const userId = authenticatedUserId ?? requestedUserId ?? null;
     const term = searchTerm.trim();
+    const cutoff = new Date(Date.now() - hoursOld * 60 * 60 * 1000).toISOString();
 
-    // Build PostgREST query filters
-    const select = [
+    // ── Log search (fire-and-forget) ──────────────────────────────────────────
+    if (userId) {
+      pgrest("search_queries", "", {
+        method: "POST",
+        body: JSON.stringify({
+          user_id: userId,
+          search_term: term,
+          location: location ?? null,
+          is_remote: isRemote ?? null,
+        }),
+        prefer: "return=minimal",
+      }).catch(() => {});
+    }
+
+    // ── Query job_postings ────────────────────────────────────────────────────
+    const selectCols = [
       "id", "external_id", "title", "company", "location", "is_remote",
       "job_type", "salary_min", "salary_max", "salary_currency",
-      "description", "job_url", "source", "date_posted", "scraped_at",
+      "description", "job_url", "apply_url", "source", "date_posted", "scraped_at",
     ].join(",");
 
     const filters: string[] = [
-      `select=${select}`,
-      `or=(title.ilike.*${encodeURIComponent(term)}*,company.ilike.*${encodeURIComponent(term)}*,description.ilike.*${encodeURIComponent(term)}*)`,
+      `select=${selectCols}`,
+      `status=eq.active`,
       `scraped_at=gte.${cutoff}`,
+      `or=(title.ilike.*${encodeURIComponent(term)}*,company.ilike.*${encodeURIComponent(term)}*,description.ilike.*${encodeURIComponent(term)}*)`,
       `order=scraped_at.desc`,
       `offset=${offset}`,
-      `limit=${limit}`,
+      `limit=${Math.min(limit, 200)}`,
     ];
 
-    if (location)  filters.push(`location=ilike.*${encodeURIComponent(location)}*`);
-    if (isRemote)  filters.push(`is_remote=eq.true`);
-    if (jobType)   filters.push(`job_type=eq.${encodeURIComponent(jobType)}`);
+    if (location && location.toLowerCase() !== "remote") {
+      filters.push(`location=ilike.*${encodeURIComponent(location)}*`);
+    }
+    if (isRemote) filters.push(`is_remote=eq.true`);
+    if (jobType)  filters.push(`job_type=eq.${encodeURIComponent(jobType)}`);
     if (salaryMin) filters.push(`salary_min=gte.${salaryMin}`);
 
-    const jobs: any[] = await pgrest("job_postings", filters.join("&"));
+    const jobs: any[] = (await pgrest("job_postings", filters.join("&"))) ?? [];
 
-    // Enrich with cached fit scores if userId provided
-    let jobsWithScores = jobs ?? [];
+    // ── Enrich with AI fit scores ─────────────────────────────────────────────
+    let jobsWithScores = jobs;
+    let matchingTriggered = false;
+
     if (userId && jobsWithScores.length > 0) {
       const jobIds = jobsWithScores.map((j: any) => j.id);
+
       try {
+        // Fetch cached matches for these specific jobs
         const matches: any[] = await pgrest(
           "user_job_matches",
-          `select=job_posting_id,fit_score,skill_gaps,match_reasons&user_id=eq.${userId}&job_posting_id=in.(${jobIds.join(",")})`,
+          `select=job_id,fit_score,matched_skills,skill_gaps,strengths,red_flags,match_summary,effort_level,response_prob,smart_tag,is_saved,is_ignored,is_applied` +
+          `&user_id=eq.${userId}` +
+          `&job_id=in.(${jobIds.join(",")})` +
+          `&is_ignored=eq.false`
         );
 
         if (matches?.length) {
-          const matchMap = Object.fromEntries(
-            matches.map((m: any) => [m.job_posting_id, m]),
-          );
-          jobsWithScores = jobsWithScores.map((job: any) => ({
-            ...job,
-            fit_score: matchMap[job.id]?.fit_score ?? null,
-            skill_gaps: matchMap[job.id]?.skill_gaps ?? [],
-            match_reasons: matchMap[job.id]?.match_reasons ?? [],
-          }));
+          const matchMap = new Map(matches.map((m: any) => [m.job_id, m]));
 
+          jobsWithScores = jobsWithScores
+            .filter((j: any) => {
+              const m = matchMap.get(j.id);
+              return !m?.is_ignored; // hide ignored jobs
+            })
+            .map((job: any) => {
+              const m = matchMap.get(job.id);
+              return m ? {
+                ...job,
+                fit_score: m.fit_score,
+                matched_skills: m.matched_skills ?? [],
+                skill_gaps: m.skill_gaps ?? [],
+                strengths: m.strengths ?? [],
+                red_flags: m.red_flags ?? [],
+                match_summary: m.match_summary ?? "",
+                effort_level: m.effort_level,
+                response_prob: m.response_prob,
+                smart_tag: m.smart_tag,
+                is_saved: m.is_saved ?? false,
+                is_applied: m.is_applied ?? false,
+              } : { ...job, fit_score: null };
+            });
+
+          // Apply minFitScore filter (only to jobs that have been scored)
           if (minFitScore && minFitScore > 0) {
             jobsWithScores = jobsWithScores.filter(
-              (j: any) => j.fit_score === null || j.fit_score >= minFitScore,
+              (j: any) => j.fit_score === null || j.fit_score >= minFitScore
             );
           }
 
+          // Sort: scored jobs first (by score desc), then unscored
           jobsWithScores.sort((a: any, b: any) => {
             if (a.fit_score === null && b.fit_score === null) return 0;
             if (a.fit_score === null) return 1;
@@ -140,25 +239,46 @@ Deno.serve(async (req) => {
             return b.fit_score - a.fit_score;
           });
         }
-      } catch {
-        // user_job_matches table may not exist yet — skip enrichment
+
+        // Trigger background matching if there are unscored jobs
+        const scoredIds = new Set(matches?.map((m: any) => m.job_id) ?? []);
+        const unscoredCount = jobIds.filter((id: string) => !scoredIds.has(id)).length;
+
+        if (triggerMatch && unscoredCount > 0 && token) {
+          triggerBackgroundMatch(token, userId);
+          matchingTriggered = true;
+          console.log(`[discover-jobs] Triggered background match for ${unscoredCount} unscored jobs (user ${userId})`);
+        }
+
+      } catch (enrichErr) {
+        // user_job_matches may not exist yet — skip enrichment gracefully
+        console.warn("[discover-jobs] Enrichment skipped:", enrichErr instanceof Error ? enrichErr.message : enrichErr);
+
+        // Still trigger matching so the table gets populated
+        if (triggerMatch && token) {
+          triggerBackgroundMatch(token, userId);
+          matchingTriggered = true;
+        }
       }
     }
 
-    return new Response(
-      JSON.stringify({
-        jobs: jobsWithScores,
-        total: jobsWithScores.length,
-        searchTerm,
-        source: "icareeros-native-v5",
-      }),
-      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
-    );
+    return jsonRes({
+      jobs: jobsWithScores,
+      total: jobsWithScores.length,
+      searchTerm: term,
+      matchingTriggered,
+      source: "icareeros-native-v6",
+    });
+
   } catch (err) {
-    console.error("discover-jobs error:", err);
-    return new Response(
-      JSON.stringify({ error: "Internal server error" }),
-      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
-    );
+    console.error("[discover-jobs] Error:", err);
+    return jsonRes({ error: "Internal server error" }, 500);
   }
 });
+
+function jsonRes(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/functions/job-feeds/index.ts
+++ b/supabase/functions/job-feeds/index.ts
@@ -1,0 +1,542 @@
+/**
+ * job-feeds — Live Job Ingestion Agent (Supabase Edge Function, Deno)
+ *
+ * Fetches fresh job postings from public APIs and RSS feeds, normalizes them,
+ * and upserts into job_postings. No third-party paid services required.
+ *
+ * Sources (all free, no API key needed):
+ *   remotive      — https://remotive.com/api/remote-jobs  (JSON)
+ *   weworkremotely— https://weworkremotely.com/...rss     (RSS/XML)
+ *   greenhouse    — boards-api.greenhouse.io               (JSON, per board)
+ *   lever         — api.lever.co                           (JSON, per company)
+ *   arbeitnow     — https://arbeitnow.com/api/job-board-api (JSON, EU-focused)
+ *
+ * Triggered by:
+ *   - GitHub Actions cron (every 2 hours)
+ *   - Admin manual trigger
+ *   - POST /job-feeds with { source: "all" | "remotive" | ... }
+ *
+ * POST body:
+ *   { source?: string, boards?: string[] }
+ *   boards = Greenhouse board tokens or Lever company slugs to fetch
+ *
+ * Response:
+ *   { ingested: number, sources: { [source]: { new, updated, error } } }
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { cleanJobText } from "../_shared/job-parser.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+// ---------------------------------------------------------------------------
+// Normalized job structure for ingestion
+// ---------------------------------------------------------------------------
+
+interface NormalizedJob {
+  external_id: string;    // unique ID for deduplication
+  title: string;
+  company: string;
+  location: string;
+  is_remote: boolean;
+  job_type: string;       // 'fulltime' | 'parttime' | 'contract' | 'internship'
+  description: string;    // cleaned by job-parser
+  job_url: string;
+  apply_url: string;
+  source: string;
+  salary_min: number | null;
+  salary_max: number | null;
+  date_posted: string;    // ISO timestamp
+}
+
+interface SourceResult {
+  source: string;
+  new: number;
+  updated: number;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeJobType(raw: string): string {
+  const t = raw.toLowerCase().replace(/[^a-z]/g, "");
+  if (t.includes("part")) return "parttime";
+  if (t.includes("contract") || t.includes("freelance")) return "contract";
+  if (t.includes("intern")) return "internship";
+  return "fulltime";
+}
+
+function extractSalary(text: string): { min: number | null; max: number | null } {
+  const m = text.match(/\$\s*([\d,]+)(?:\s*[-–]\s*\$?\s*([\d,]+))?/);
+  if (!m) return { min: null, max: null };
+  const min = parseInt(m[1].replace(/,/g, ""), 10);
+  const max = m[2] ? parseInt(m[2].replace(/,/g, ""), 10) : null;
+  // If values look like hourly rates, convert to annual
+  const annualMin = min < 500 ? min * 2080 : min;
+  const annualMax = max ? (max < 500 ? max * 2080 : max) : null;
+  return { min: annualMin, max: annualMax };
+}
+
+// ---------------------------------------------------------------------------
+// Source 1: Remotive — best free remote jobs API
+// https://remotive.com/api/remote-jobs?category=software-dev&limit=50
+// ---------------------------------------------------------------------------
+
+const REMOTIVE_CATEGORIES = [
+  "software-dev", "devops-sysadmin", "product", "design",
+  "data", "qa", "cybersecurity", "finance-legal", "marketing",
+];
+
+async function fetchRemotive(): Promise<{ jobs: NormalizedJob[]; error?: string }> {
+  const allJobs: NormalizedJob[] = [];
+  const errors: string[] = [];
+
+  for (const category of REMOTIVE_CATEGORIES) {
+    try {
+      const url = `https://remotive.com/api/remote-jobs?category=${category}&limit=50`;
+      const res = await fetch(url, { signal: AbortSignal.timeout(12_000) });
+      if (!res.ok) { errors.push(`remotive/${category}: HTTP ${res.status}`); continue; }
+
+      const data = await res.json();
+      const jobs: any[] = data.jobs ?? [];
+
+      for (const job of jobs) {
+        const salary = extractSalary(job.salary ?? "");
+        allJobs.push({
+          external_id: `remotive-${job.id}`,
+          title: job.title ?? "",
+          company: job.company_name ?? "",
+          location: job.candidate_required_location || "Worldwide",
+          is_remote: true,
+          job_type: normalizeJobType(job.job_type ?? "full_time"),
+          description: cleanJobText(job.description?.replace(/<[^>]+>/g, " ") ?? "", job.title),
+          job_url: job.url ?? "",
+          apply_url: job.url ?? "",
+          source: "remotive",
+          salary_min: salary.min,
+          salary_max: salary.max,
+          date_posted: job.publication_date ?? new Date().toISOString(),
+        });
+      }
+    } catch (e) {
+      errors.push(`remotive/${category}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return { jobs: allJobs, error: errors.length > 0 ? errors.join("; ") : undefined };
+}
+
+// ---------------------------------------------------------------------------
+// Source 2: We Work Remotely — RSS feed
+// ---------------------------------------------------------------------------
+
+const WWR_FEEDS = [
+  "https://weworkremotely.com/categories/remote-full-stack-programming-jobs.rss",
+  "https://weworkremotely.com/categories/remote-back-end-programming-jobs.rss",
+  "https://weworkremotely.com/categories/remote-front-end-programming-jobs.rss",
+  "https://weworkremotely.com/categories/remote-devops-sysadmin-jobs.rss",
+  "https://weworkremotely.com/categories/remote-product-jobs.rss",
+  "https://weworkremotely.com/categories/remote-design-jobs.rss",
+  "https://weworkremotely.com/categories/remote-data-science-ai-statistics-jobs.rss",
+];
+
+function parseRssItem(item: string): { title?: string; link?: string; description?: string; company?: string; pubDate?: string } {
+  const get = (tag: string) => {
+    const m = item.match(new RegExp(`<${tag}[^>]*>(?:<!\\[CDATA\\[)?([\\s\\S]*?)(?:\\]\\]>)?<\\/${tag}>`, "i"));
+    return m?.[1]?.trim();
+  };
+  const title = get("title") ?? "";
+  // WWR title format: "Company: Job Title"
+  const colonIdx = title.indexOf(":");
+  const company = colonIdx > 0 ? title.slice(0, colonIdx).trim() : "";
+  const jobTitle = colonIdx > 0 ? title.slice(colonIdx + 1).trim() : title;
+  return {
+    title: jobTitle,
+    company,
+    link: get("link"),
+    description: get("description"),
+    pubDate: get("pubDate"),
+  };
+}
+
+async function fetchWeWorkRemotely(): Promise<{ jobs: NormalizedJob[]; error?: string }> {
+  const allJobs: NormalizedJob[] = [];
+  const errors: string[] = [];
+
+  for (const feedUrl of WWR_FEEDS) {
+    try {
+      const res = await fetch(feedUrl, {
+        headers: { "User-Agent": "iCareerOS/1.0" },
+        signal: AbortSignal.timeout(12_000),
+      });
+      if (!res.ok) { errors.push(`wwr: HTTP ${res.status}`); continue; }
+
+      const xml = await res.text();
+      const items = xml.match(/<item>([\s\S]*?)<\/item>/gi) ?? [];
+
+      for (const item of items) {
+        const parsed = parseRssItem(item);
+        if (!parsed.title || !parsed.link) continue;
+
+        const hash = btoa(parsed.link).replace(/[^a-z0-9]/gi, "").slice(0, 32);
+        const salary = extractSalary(parsed.description ?? "");
+        const desc = (parsed.description ?? "").replace(/<[^>]+>/g, " ");
+
+        allJobs.push({
+          external_id: `wwr-${hash}`,
+          title: parsed.title,
+          company: parsed.company ?? "",
+          location: "Remote",
+          is_remote: true,
+          job_type: "fulltime",
+          description: cleanJobText(desc, parsed.title),
+          job_url: parsed.link,
+          apply_url: parsed.link,
+          source: "weworkremotely",
+          salary_min: salary.min,
+          salary_max: salary.max,
+          date_posted: parsed.pubDate ? new Date(parsed.pubDate).toISOString() : new Date().toISOString(),
+        });
+      }
+    } catch (e) {
+      errors.push(`wwr: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return { jobs: allJobs, error: errors.length > 0 ? errors.join("; ") : undefined };
+}
+
+// ---------------------------------------------------------------------------
+// Source 3: Arbeitnow — free job board API (tech-focused, global)
+// https://arbeitnow.com/api/job-board-api
+// ---------------------------------------------------------------------------
+
+async function fetchArbeitnow(): Promise<{ jobs: NormalizedJob[]; error?: string }> {
+  try {
+    const res = await fetch("https://arbeitnow.com/api/job-board-api", {
+      headers: { "Accept": "application/json" },
+      signal: AbortSignal.timeout(12_000),
+    });
+    if (!res.ok) return { jobs: [], error: `arbeitnow: HTTP ${res.status}` };
+
+    const data = await res.json();
+    const items: any[] = data.data ?? [];
+
+    const jobs: NormalizedJob[] = items.map((job) => {
+      const salary = extractSalary(job.description ?? "");
+      return {
+        external_id: `arbeitnow-${job.slug}`,
+        title: job.title ?? "",
+        company: job.company_name ?? "",
+        location: job.location || (job.remote ? "Remote" : ""),
+        is_remote: job.remote ?? false,
+        job_type: normalizeJobType(job.job_types?.[0] ?? "full_time"),
+        description: cleanJobText((job.description ?? "").replace(/<[^>]+>/g, " "), job.title),
+        job_url: job.url ?? "",
+        apply_url: job.url ?? "",
+        source: "arbeitnow",
+        salary_min: salary.min,
+        salary_max: salary.max,
+        date_posted: job.created_at ? new Date(job.created_at * 1000).toISOString() : new Date().toISOString(),
+      };
+    });
+
+    return { jobs };
+  } catch (e) {
+    return { jobs: [], error: `arbeitnow: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source 4: Greenhouse boards — list of popular tech company boards
+// (Add more boards here as needed — all are free public APIs)
+// ---------------------------------------------------------------------------
+
+const GREENHOUSE_BOARDS = [
+  "anthropic", "stripe", "vercel", "supabase", "linear", "notion",
+  "figma", "airbnb", "shopify", "databricks", "snowflake", "hashicorp",
+  "cloudflare", "twilio", "datadog", "confluent", "asana",
+];
+
+async function fetchGreenhouseBoards(boards: string[]): Promise<{ jobs: NormalizedJob[]; error?: string }> {
+  const allJobs: NormalizedJob[] = [];
+  const errors: string[] = [];
+
+  await Promise.allSettled(
+    boards.map(async (board) => {
+      try {
+        const url = `https://boards-api.greenhouse.io/v1/boards/${board}/jobs?content=true`;
+        const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+        if (!res.ok) { errors.push(`greenhouse/${board}: HTTP ${res.status}`); return; }
+
+        const data = await res.json();
+        const company = data.name ?? board;
+
+        for (const job of (data.jobs ?? [])) {
+          const salary = extractSalary(job.content ?? "");
+          const desc = (job.content ?? "").replace(/<[^>]+>/g, " ");
+          allJobs.push({
+            external_id: `greenhouse-${board}-${job.id}`,
+            title: job.title ?? "",
+            company,
+            location: job.location?.name ?? "",
+            is_remote: /remote/i.test(job.location?.name ?? "") || /remote/i.test(job.title),
+            job_type: "fulltime",
+            description: cleanJobText(desc, job.title),
+            job_url: job.absolute_url ?? "",
+            apply_url: job.absolute_url ?? "",
+            source: `greenhouse:${board}`,
+            salary_min: salary.min,
+            salary_max: salary.max,
+            date_posted: job.updated_at ?? new Date().toISOString(),
+          });
+        }
+      } catch (e) {
+        errors.push(`greenhouse/${board}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    })
+  );
+
+  return { jobs: allJobs, error: errors.length > 0 ? errors.slice(0, 3).join("; ") : undefined };
+}
+
+// ---------------------------------------------------------------------------
+// Source 5: Lever boards — popular companies using Lever
+// ---------------------------------------------------------------------------
+
+const LEVER_COMPANIES = [
+  "netflix", "reddit", "lyft", "coinbase", "robinhood",
+  "duolingo", "canva", "discord", "plaid", "brex",
+];
+
+async function fetchLeverBoards(companies: string[]): Promise<{ jobs: NormalizedJob[]; error?: string }> {
+  const allJobs: NormalizedJob[] = [];
+  const errors: string[] = [];
+
+  await Promise.allSettled(
+    companies.map(async (company) => {
+      try {
+        const url = `https://api.lever.co/v0/postings/${company}?mode=json`;
+        const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+        if (!res.ok) { errors.push(`lever/${company}: HTTP ${res.status}`); return; }
+
+        const jobs: any[] = await res.json();
+        for (const job of jobs) {
+          const desc = [job.descriptionPlain, job.additionalPlain].filter(Boolean).join("\n\n");
+          const salary = extractSalary(desc);
+          allJobs.push({
+            external_id: `lever-${company}-${job.id}`,
+            title: job.text ?? "",
+            company,
+            location: job.categories?.location ?? "",
+            is_remote: /remote/i.test(job.categories?.location ?? "") || /remote/i.test(job.text),
+            job_type: normalizeJobType(job.categories?.commitment ?? "full-time"),
+            description: cleanJobText(desc, job.text),
+            job_url: job.hostedUrl ?? "",
+            apply_url: job.applyUrl ?? job.hostedUrl ?? "",
+            source: `lever:${company}`,
+            salary_min: salary.min,
+            salary_max: salary.max,
+            date_posted: job.createdAt ? new Date(job.createdAt).toISOString() : new Date().toISOString(),
+          });
+        }
+      } catch (e) {
+        errors.push(`lever/${company}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    })
+  );
+
+  return { jobs: allJobs, error: errors.length > 0 ? errors.slice(0, 3).join("; ") : undefined };
+}
+
+// ---------------------------------------------------------------------------
+// DB upsert
+// ---------------------------------------------------------------------------
+
+async function upsertJobs(
+  supabase: any,
+  jobs: NormalizedJob[],
+  source: string
+): Promise<{ new: number; updated: number; error?: string }> {
+  if (jobs.length === 0) return { new: 0, updated: 0 };
+
+  const rows = jobs
+    .filter((j) => j.title && j.company && j.job_url)
+    .map((j) => ({
+      external_id: j.external_id,
+      title: j.title.slice(0, 255),
+      company: j.company.slice(0, 255),
+      location: j.location.slice(0, 255),
+      is_remote: j.is_remote,
+      job_type: j.job_type,
+      description: j.description.slice(0, 20_000),
+      job_url: j.job_url.slice(0, 2048),
+      apply_url: j.apply_url.slice(0, 2048),
+      source: j.source,
+      salary_min: j.salary_min,
+      salary_max: j.salary_max,
+      date_posted: j.date_posted,
+      scraped_at: new Date().toISOString(),
+      status: "active",
+    }));
+
+  // Get existing external_ids to distinguish new vs updated
+  const externalIds = rows.map((r) => r.external_id);
+  const { data: existing } = await supabase
+    .from("job_postings")
+    .select("external_id")
+    .in("external_id", externalIds);
+
+  const existingSet = new Set((existing ?? []).map((r: any) => r.external_id));
+  const newCount = rows.filter((r) => !existingSet.has(r.external_id)).length;
+  const updatedCount = rows.filter((r) => existingSet.has(r.external_id)).length;
+
+  const { error } = await supabase
+    .from("job_postings")
+    .upsert(rows, { onConflict: "external_id", ignoreDuplicates: false });
+
+  if (error) {
+    console.error(`[job-feeds] upsert error for ${source}:`, error);
+    return { new: 0, updated: 0, error: error.message };
+  }
+
+  return { new: newCount, updated: updatedCount };
+}
+
+// ---------------------------------------------------------------------------
+// Feed log writer
+// ---------------------------------------------------------------------------
+
+async function logFeedRun(
+  supabase: any,
+  source: string,
+  jobsFound: number,
+  jobsNew: number,
+  jobsUpdated: number,
+  durationMs: number,
+  error?: string
+) {
+  await supabase.from("job_feed_log").insert({
+    source, jobs_found: jobsFound, jobs_new: jobsNew,
+    jobs_updated: jobsUpdated, duration_ms: durationMs, error: error ?? null,
+  }).catch(() => {}); // non-fatal
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  const startTime = Date.now();
+
+  try {
+    // ── Auth (service role or admin user) ─────────────────────────────────────
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return res({ success: false, error: "Missing authorization header" }, 401);
+    }
+
+    // Allow service role key OR authenticated admin
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    );
+
+    const body = await req.json().catch(() => ({}));
+    const requestedSource: string = body.source ?? "all";
+    const customBoards: string[] = body.boards ?? [];
+    const customCompanies: string[] = body.companies ?? [];
+
+    const results: Record<string, SourceResult> = {};
+    let totalIngested = 0;
+
+    // ── Run selected sources in parallel ─────────────────────────────────────
+    const sourceTasks: Array<() => Promise<void>> = [];
+
+    if (requestedSource === "all" || requestedSource === "remotive") {
+      sourceTasks.push(async () => {
+        const fetchStart = Date.now();
+        const { jobs, error } = await fetchRemotive();
+        const { new: n, updated: u, error: dbErr } = await upsertJobs(supabaseAdmin, jobs, "remotive");
+        results["remotive"] = { source: "remotive", new: n, updated: u, error: error ?? dbErr };
+        totalIngested += n + u;
+        await logFeedRun(supabaseAdmin, "remotive", jobs.length, n, u, Date.now() - fetchStart, error ?? dbErr);
+      });
+    }
+
+    if (requestedSource === "all" || requestedSource === "weworkremotely") {
+      sourceTasks.push(async () => {
+        const fetchStart = Date.now();
+        const { jobs, error } = await fetchWeWorkRemotely();
+        const { new: n, updated: u, error: dbErr } = await upsertJobs(supabaseAdmin, jobs, "weworkremotely");
+        results["weworkremotely"] = { source: "weworkremotely", new: n, updated: u, error: error ?? dbErr };
+        totalIngested += n + u;
+        await logFeedRun(supabaseAdmin, "weworkremotely", jobs.length, n, u, Date.now() - fetchStart, error ?? dbErr);
+      });
+    }
+
+    if (requestedSource === "all" || requestedSource === "arbeitnow") {
+      sourceTasks.push(async () => {
+        const fetchStart = Date.now();
+        const { jobs, error } = await fetchArbeitnow();
+        const { new: n, updated: u, error: dbErr } = await upsertJobs(supabaseAdmin, jobs, "arbeitnow");
+        results["arbeitnow"] = { source: "arbeitnow", new: n, updated: u, error: error ?? dbErr };
+        totalIngested += n + u;
+        await logFeedRun(supabaseAdmin, "arbeitnow", jobs.length, n, u, Date.now() - fetchStart, error ?? dbErr);
+      });
+    }
+
+    if (requestedSource === "all" || requestedSource === "greenhouse") {
+      const boards = customBoards.length > 0 ? customBoards : GREENHOUSE_BOARDS;
+      sourceTasks.push(async () => {
+        const fetchStart = Date.now();
+        const { jobs, error } = await fetchGreenhouseBoards(boards);
+        const { new: n, updated: u, error: dbErr } = await upsertJobs(supabaseAdmin, jobs, "greenhouse");
+        results["greenhouse"] = { source: "greenhouse", new: n, updated: u, error: error ?? dbErr };
+        totalIngested += n + u;
+        await logFeedRun(supabaseAdmin, "greenhouse", jobs.length, n, u, Date.now() - fetchStart, error ?? dbErr);
+      });
+    }
+
+    if (requestedSource === "all" || requestedSource === "lever") {
+      const companies = customCompanies.length > 0 ? customCompanies : LEVER_COMPANIES;
+      sourceTasks.push(async () => {
+        const fetchStart = Date.now();
+        const { jobs, error } = await fetchLeverBoards(companies);
+        const { new: n, updated: u, error: dbErr } = await upsertJobs(supabaseAdmin, jobs, "lever");
+        results["lever"] = { source: "lever", new: n, updated: u, error: error ?? dbErr };
+        totalIngested += n + u;
+        await logFeedRun(supabaseAdmin, "lever", jobs.length, n, u, Date.now() - fetchStart, error ?? dbErr);
+      });
+    }
+
+    await Promise.allSettled(sourceTasks.map((t) => t()));
+
+    console.log(`[job-feeds] Complete: ${totalIngested} jobs ingested in ${Date.now() - startTime}ms`);
+
+    return res({
+      success: true,
+      ingested: totalIngested,
+      durationMs: Date.now() - startTime,
+      sources: results,
+    });
+
+  } catch (error) {
+    console.error("[job-feeds] Unhandled error:", error);
+    return res({ success: false, error: error instanceof Error ? error.message : "Feed ingestion failed" }, 500);
+  }
+});
+
+function res(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/functions/match-jobs/index.ts
+++ b/supabase/functions/match-jobs/index.ts
@@ -1,0 +1,449 @@
+/**
+ * match-jobs — AI Job Matching Agent (Supabase Edge Function, Deno)
+ *
+ * Scores unmatched job postings against a user's Career Profile using Claude.
+ * Results are stored in `user_job_matches` and immediately available to the
+ * discover-jobs function for enriched search results.
+ *
+ * How it works:
+ *  1. Load user's Career Profile (skills, titles, experience, location prefs)
+ *  2. Find unscored jobs from job_postings (new since last run)
+ *  3. Clean each job description with job-parser (strips benefits/EEO noise)
+ *  4. Batch 10 jobs per Claude call (cost-efficient)
+ *  5. Parse Claude's JSON → upsert to user_job_matches
+ *  6. Return top N matches sorted by fit_score
+ *
+ * Called by:
+ *  - discover-jobs (on-demand, triggered when user searches)
+ *  - job-alerts (scheduled, runs nightly for alert delivery)
+ *  - Direct API calls for background pre-scoring
+ *
+ * POST body:
+ *  {
+ *    userId?: string        — score for this user (defaults to authenticated user)
+ *    limit?: number         — max jobs to score per call (default 50, max 200)
+ *    forceRescore?: boolean — re-score even if already matched
+ *    jobIds?: string[]      — score specific jobs only
+ *  }
+ *
+ * Response:
+ *  { scored: number, topMatches: MatchResult[], skipped: number }
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { checkRateLimit } from "../_shared/rate-limit.ts";
+import { cleanJobText } from "../_shared/job-parser.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+const ANTHROPIC_API = "https://api.anthropic.com/v1/messages";
+const BATCH_SIZE = 10;          // jobs per Claude call
+const MAX_JOB_CHARS = 2_000;    // trim job descriptions to keep prompts focused
+const MAX_JOBS_PER_RUN = 200;   // cap to prevent runaway costs
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface UserProfile {
+  userId: string;
+  fullName: string;
+  skills: string[];
+  certifications: string[];
+  targetTitles: string[];
+  careerLevel: string;
+  location: string;
+  isRemote: boolean;
+  salaryMin: number;
+  salaryMax: number;
+  summary: string;
+  experienceYears: number;
+}
+
+interface JobPosting {
+  id: string;
+  title: string;
+  company: string;
+  location: string;
+  is_remote: boolean;
+  description: string;
+  salary_min: number | null;
+  salary_max: number | null;
+  job_type: string;
+}
+
+interface MatchResult {
+  job_id: string;
+  fit_score: number;
+  matched_skills: string[];
+  skill_gaps: string[];
+  strengths: string[];
+  red_flags: string[];
+  match_summary: string;
+  effort_level: "easy" | "moderate" | "hard";
+  response_prob: number;
+  smart_tag: string;
+}
+
+// ---------------------------------------------------------------------------
+// Profile loader
+// ---------------------------------------------------------------------------
+
+async function loadUserProfile(supabase: any, userId: string): Promise<UserProfile | null> {
+  const { data, error } = await supabase
+    .from("job_seeker_profiles")
+    .select(`
+      user_id, full_name, skills, certifications, target_job_titles,
+      career_level, location, preferred_job_types, salary_min, salary_max,
+      summary, work_experience, automation_mode
+    `)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  // Estimate experience years from work_experience jsonb
+  let experienceYears = 0;
+  if (Array.isArray(data.work_experience)) {
+    experienceYears = data.work_experience.reduce((acc: number, job: any) => {
+      const start = job.start_year ?? job.startYear ?? 0;
+      const end = job.end_year ?? job.endYear ?? new Date().getFullYear();
+      return acc + Math.max(0, end - start);
+    }, 0);
+  }
+
+  const isRemote = (data.preferred_job_types ?? []).some((t: string) =>
+    /remote/i.test(t)
+  );
+
+  return {
+    userId: data.user_id,
+    fullName: data.full_name ?? "",
+    skills: data.skills ?? [],
+    certifications: data.certifications ?? [],
+    targetTitles: data.target_job_titles ?? [],
+    careerLevel: data.career_level ?? "mid",
+    location: data.location ?? "",
+    isRemote,
+    salaryMin: data.salary_min ?? 0,
+    salaryMax: data.salary_max ?? 0,
+    summary: data.summary ?? "",
+    experienceYears,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unmatched job fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchUnmatchedJobs(
+  supabase: any,
+  userId: string,
+  limit: number,
+  jobIds?: string[],
+  forceRescore = false
+): Promise<JobPosting[]> {
+  let query = supabase
+    .from("job_postings")
+    .select("id, title, company, location, is_remote, description, salary_min, salary_max, job_type")
+    .eq("status", "active")
+    .order("date_posted", { ascending: false })
+    .limit(limit);
+
+  if (jobIds?.length) {
+    query = query.in("id", jobIds);
+  } else if (!forceRescore) {
+    // Exclude already-scored jobs for this user
+    const { data: existing } = await supabase
+      .from("user_job_matches")
+      .select("job_id")
+      .eq("user_id", userId)
+      .eq("is_ignored", false);
+
+    const existingIds = (existing ?? []).map((r: any) => r.job_id);
+    if (existingIds.length > 0) {
+      query = query.not("id", "in", `(${existingIds.join(",")})`);
+    }
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    console.error("[match-jobs] fetchUnmatchedJobs error:", error);
+    return [];
+  }
+  return data ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Claude scoring prompt
+// ---------------------------------------------------------------------------
+
+function buildMatchingPrompt(profile: UserProfile, jobs: JobPosting[]): string {
+  const profileSummary = `
+CANDIDATE PROFILE:
+Name: ${profile.fullName}
+Career Level: ${profile.careerLevel}
+Years of Experience: ~${profile.experienceYears}
+Target Titles: ${profile.targetTitles.join(", ") || "Not specified"}
+Skills: ${profile.skills.join(", ") || "Not specified"}
+Certifications: ${profile.certifications.join(", ") || "None"}
+Location: ${profile.location || "Not specified"} ${profile.isRemote ? "(Open to remote)" : ""}
+Salary Expectation: ${profile.salaryMin ? `$${profile.salaryMin.toLocaleString()}` : "Not specified"} - ${profile.salaryMax ? `$${profile.salaryMax.toLocaleString()}` : "Not specified"}
+Summary: ${profile.summary || "Not provided"}
+`.trim();
+
+  const jobsText = jobs
+    .map((job, i) => {
+      const cleanDesc = cleanJobText(job.description ?? "", job.title).slice(0, MAX_JOB_CHARS);
+      const salary = job.salary_min
+        ? `$${job.salary_min.toLocaleString()}${job.salary_max ? ` - $${job.salary_max.toLocaleString()}` : "+"}`
+        : "Not listed";
+      return `JOB ${i + 1} [ID: ${job.id}]:
+Title: ${job.title}
+Company: ${job.company}
+Location: ${job.location}${job.is_remote ? " (Remote)" : ""}
+Type: ${job.job_type}
+Salary: ${salary}
+Description:
+${cleanDesc}`;
+    })
+    .join("\n\n---\n\n");
+
+  return `${profileSummary}
+
+You are an expert career coach and recruiter. Analyze each job below against the candidate profile and score the fit.
+
+${jobsText}
+
+For EACH job, return a JSON object in this exact array format. Be honest and calibrated — most jobs should score 40-75, true excellent matches 76-90, stretch goals 91-100.
+
+Return ONLY valid JSON array, no markdown, no explanation:
+[
+  {
+    "job_id": "exact UUID from [ID: ...]",
+    "fit_score": 0-100,
+    "matched_skills": ["skill1", "skill2"],
+    "skill_gaps": ["missing_skill1", "missing_skill2"],
+    "strengths": ["one strength", "another strength"],
+    "red_flags": ["concern if any"],
+    "match_summary": "One sentence explaining why this is or isn't a good fit.",
+    "effort_level": "easy|moderate|hard",
+    "response_prob": 0-100,
+    "smart_tag": "hot_match|good_fit|stretch|reach|low_roi|apply_fast"
+  }
+]
+
+Rules:
+- fit_score: skills overlap (40%), title/level match (25%), location/remote (15%), salary (10%), growth potential (10%)
+- matched_skills: only skills from the candidate's profile that appear in the job requirements
+- skill_gaps: key requirements the candidate clearly lacks
+- effort_level: easy=strong match/apply now, moderate=worth tailoring resume, hard=significant gaps
+- response_prob: probability employer responds (based on fit + company tier + job competitiveness)
+- smart_tag: hot_match(90+), good_fit(75-89), stretch(60-74), reach(40-59), low_roi(strong match but poor comp/growth), apply_fast(time-sensitive or limited applicants)`;
+}
+
+// ---------------------------------------------------------------------------
+// Claude API caller
+// ---------------------------------------------------------------------------
+
+async function scoreWithClaude(
+  apiKey: string,
+  prompt: string
+): Promise<MatchResult[]> {
+  const response = await fetch(ANTHROPIC_API, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: "claude-haiku-4-5-20251001",  // Fastest + cheapest for batch scoring
+      max_tokens: 4_000,
+      messages: [{ role: "user", content: prompt }],
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`Claude API error ${response.status}: ${err.slice(0, 200)}`);
+  }
+
+  const data = await response.json();
+  const text = data.content?.[0]?.text ?? "[]";
+
+  // Claude sometimes wraps JSON in markdown fences — strip them
+  const clean = text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "").trim();
+
+  try {
+    const parsed = JSON.parse(clean);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    console.error("[match-jobs] Failed to parse Claude response:", text.slice(0, 500));
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DB writer
+// ---------------------------------------------------------------------------
+
+async function saveMatches(
+  supabase: any,
+  userId: string,
+  matches: MatchResult[]
+): Promise<number> {
+  if (matches.length === 0) return 0;
+
+  const rows = matches.map((m) => ({
+    user_id: userId,
+    job_id: m.job_id,
+    fit_score: Math.max(0, Math.min(100, m.fit_score ?? 0)),
+    matched_skills: m.matched_skills ?? [],
+    skill_gaps: m.skill_gaps ?? [],
+    strengths: m.strengths ?? [],
+    red_flags: m.red_flags ?? [],
+    match_summary: m.match_summary ?? "",
+    effort_level: ["easy", "moderate", "hard"].includes(m.effort_level) ? m.effort_level : "moderate",
+    response_prob: Math.max(0, Math.min(100, m.response_prob ?? 50)),
+    smart_tag: m.smart_tag ?? "good_fit",
+    scored_at: new Date().toISOString(),
+  }));
+
+  const { error } = await supabase
+    .from("user_job_matches")
+    .upsert(rows, { onConflict: "user_id,job_id" });
+
+  if (error) {
+    console.error("[match-jobs] saveMatches error:", error);
+    return 0;
+  }
+  return rows.length;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  try {
+    // ── Auth ─────────────────────────────────────────────────────────────────
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return res({ success: false, error: "Missing authorization header" }, 401);
+    }
+
+    const supabaseAnon = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      { global: { headers: { Authorization: authHeader } } }
+    );
+    const { data, error: authError } = await (supabaseAnon.auth as any).getClaims(
+      authHeader.replace("Bearer ", "")
+    );
+    if (authError || !data?.claims) return res({ success: false, error: "Invalid or expired token" }, 401);
+    const authenticatedUserId: string = data.claims.sub;
+
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    );
+
+    // ── Rate limit ────────────────────────────────────────────────────────────
+    if (!checkRateLimit(`match-jobs:${authenticatedUserId}`, 5, 60_000)) {
+      return res({ success: false, error: "Too many match requests – please wait a moment." }, 429);
+    }
+
+    // ── Parse body ────────────────────────────────────────────────────────────
+    const body = await req.json().catch(() => ({}));
+    const userId: string = body.userId ?? authenticatedUserId;
+    const limit = Math.min(body.limit ?? 50, MAX_JOBS_PER_RUN);
+    const forceRescore: boolean = body.forceRescore ?? false;
+    const jobIds: string[] | undefined = body.jobIds;
+
+    // ── Load profile ──────────────────────────────────────────────────────────
+    const profile = await loadUserProfile(supabaseAdmin, userId);
+    if (!profile) {
+      return res({ success: false, error: "Career profile not found. Please complete your profile first." }, 404);
+    }
+    if (profile.skills.length === 0 && profile.targetTitles.length === 0) {
+      return res({ success: false, error: "Please add skills or target job titles to your profile before running matching." }, 400);
+    }
+
+    // ── Fetch unscored jobs ────────────────────────────────────────────────────
+    const jobs = await fetchUnmatchedJobs(supabaseAdmin, userId, limit, jobIds, forceRescore);
+    if (jobs.length === 0) {
+      return res({ success: true, scored: 0, topMatches: [], skipped: 0, message: "All recent jobs already matched. Check back later for new postings." });
+    }
+
+    // ── Claude API key ─────────────────────────────────────────────────────────
+    const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+    if (!apiKey) {
+      return res({ success: false, error: "AI matching not configured. Please set ANTHROPIC_API_KEY." }, 500);
+    }
+
+    // ── Batch scoring ──────────────────────────────────────────────────────────
+    let totalScored = 0;
+    const allMatches: MatchResult[] = [];
+
+    for (let i = 0; i < jobs.length; i += BATCH_SIZE) {
+      const batch = jobs.slice(i, i + BATCH_SIZE);
+      console.log(`[match-jobs] Scoring batch ${Math.floor(i / BATCH_SIZE) + 1} (${batch.length} jobs) for user ${userId}`);
+
+      try {
+        const prompt = buildMatchingPrompt(profile, batch);
+        const matches = await scoreWithClaude(apiKey, prompt);
+
+        // Validate: only accept results where job_id matches a job in the batch
+        const validJobIds = new Set(batch.map((j) => j.id));
+        const validMatches = matches.filter((m) => m.job_id && validJobIds.has(m.job_id));
+
+        const saved = await saveMatches(supabaseAdmin, userId, validMatches);
+        totalScored += saved;
+        allMatches.push(...validMatches);
+      } catch (batchError) {
+        console.error(`[match-jobs] Batch ${Math.floor(i / BATCH_SIZE) + 1} failed:`, batchError);
+        // Continue with next batch — partial results are better than none
+      }
+    }
+
+    // ── Return top matches ────────────────────────────────────────────────────
+    const topMatches = allMatches
+      .sort((a, b) => b.fit_score - a.fit_score)
+      .slice(0, 20)
+      .map((m) => ({
+        jobId: m.job_id,
+        fitScore: m.fit_score,
+        matchSummary: m.match_summary,
+        smartTag: m.smart_tag,
+        matchedSkills: m.matched_skills,
+        skillGaps: m.skill_gaps,
+      }));
+
+    console.log(`[match-jobs] Complete: scored ${totalScored}/${jobs.length} jobs for user ${userId}`);
+
+    return res({
+      success: true,
+      scored: totalScored,
+      skipped: jobs.length - totalScored,
+      topMatches,
+    });
+
+  } catch (error) {
+    console.error("[match-jobs] Unhandled error:", error);
+    return res({ success: false, error: error instanceof Error ? error.message : "Matching failed" }, 500);
+  }
+});
+
+function res(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/20260501_job_search_agent.sql
+++ b/supabase/migrations/20260501_job_search_agent.sql
@@ -1,0 +1,193 @@
+-- ============================================================================
+-- Job Search Agent Infrastructure
+--
+-- Tables:
+--   user_job_matches  — AI-scored fit results per user/job
+--   job_alerts        — User alert subscriptions
+--   job_feed_log      — Audit log of live feed fetches
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- user_job_matches
+-- Stores Claude AI match scores for every user/job pair.
+-- Populated by match-jobs edge function; read by discover-jobs for enrichment.
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_job_matches (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  job_id          uuid        NOT NULL REFERENCES job_postings(id) ON DELETE CASCADE,
+
+  -- AI-computed fit score 0–100
+  fit_score       integer     NOT NULL CHECK (fit_score BETWEEN 0 AND 100),
+
+  -- Matched skills (subset of user's skills found in job description)
+  matched_skills  text[]      NOT NULL DEFAULT '{}',
+
+  -- Skills the job requires that the user lacks
+  skill_gaps      text[]      NOT NULL DEFAULT '{}',
+
+  -- Top strengths and red flags from Claude
+  strengths       text[]      NOT NULL DEFAULT '{}',
+  red_flags       text[]      NOT NULL DEFAULT '{}',
+
+  -- One-line match summary
+  match_summary   text,
+
+  -- Effort estimate: 'easy' | 'moderate' | 'hard'
+  effort_level    text        CHECK (effort_level IN ('easy','moderate','hard')),
+
+  -- Response probability estimate 0–100
+  response_prob   integer     CHECK (response_prob BETWEEN 0 AND 100),
+
+  -- Smart tag: 'hot_match' | 'stretch' | 'apply_fast' | 'low_roi' | 'good_fit' | 'reach'
+  smart_tag       text,
+
+  -- User interaction
+  is_seen         boolean     NOT NULL DEFAULT false,
+  is_saved        boolean     NOT NULL DEFAULT false,
+  is_ignored      boolean     NOT NULL DEFAULT false,
+  is_applied      boolean     NOT NULL DEFAULT false,
+
+  scored_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE(user_id, job_id)
+);
+
+CREATE INDEX IF NOT EXISTS user_job_matches_user_score_idx
+  ON user_job_matches(user_id, fit_score DESC);
+
+CREATE INDEX IF NOT EXISTS user_job_matches_user_seen_idx
+  ON user_job_matches(user_id, is_seen, is_ignored);
+
+-- Updated-at trigger
+CREATE OR REPLACE FUNCTION update_user_job_matches_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_user_job_matches_updated_at ON user_job_matches;
+CREATE TRIGGER trg_user_job_matches_updated_at
+  BEFORE UPDATE ON user_job_matches
+  FOR EACH ROW EXECUTE FUNCTION update_user_job_matches_updated_at();
+
+-- RLS
+ALTER TABLE user_job_matches ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_own_matches" ON user_job_matches
+  FOR ALL TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "service_role_full" ON user_job_matches
+  TO service_role USING (true) WITH CHECK (true);
+
+-- ----------------------------------------------------------------------------
+-- job_alerts
+-- User subscriptions: "notify me when new {query} jobs appear"
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS job_alerts (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Alert criteria (any combination)
+  name            text        NOT NULL DEFAULT 'Job Alert',
+  search_query    text,               -- free-text keywords
+  location        text,
+  is_remote       boolean,
+  job_type        text,
+  min_fit_score   integer     DEFAULT 70 CHECK (min_fit_score BETWEEN 0 AND 100),
+  salary_min      integer,
+
+  -- Delivery settings
+  frequency       text        NOT NULL DEFAULT 'daily'
+                              CHECK (frequency IN ('realtime','daily','weekly')),
+  is_active       boolean     NOT NULL DEFAULT true,
+
+  -- Tracking
+  last_sent_at    timestamptz,
+  match_count     integer     NOT NULL DEFAULT 0,  -- total jobs sent via this alert
+
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS job_alerts_user_active_idx
+  ON job_alerts(user_id, is_active);
+
+CREATE INDEX IF NOT EXISTS job_alerts_frequency_idx
+  ON job_alerts(frequency, is_active, last_sent_at);
+
+ALTER TABLE job_alerts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_own_alerts" ON job_alerts
+  FOR ALL TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "service_role_full_alerts" ON job_alerts
+  TO service_role USING (true) WITH CHECK (true);
+
+-- ----------------------------------------------------------------------------
+-- job_feed_log
+-- Audit log of every live feed fetch (how many jobs ingested, errors, etc.)
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS job_feed_log (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  source        text        NOT NULL,    -- 'remotive' | 'weworkremotely' | 'greenhouse:{board}' | etc.
+  fetched_at    timestamptz NOT NULL DEFAULT now(),
+  jobs_found    integer     NOT NULL DEFAULT 0,
+  jobs_new      integer     NOT NULL DEFAULT 0,
+  jobs_updated  integer     NOT NULL DEFAULT 0,
+  error         text,
+  duration_ms   integer
+);
+
+CREATE INDEX IF NOT EXISTS job_feed_log_source_idx ON job_feed_log(source, fetched_at DESC);
+
+ALTER TABLE job_feed_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "service_role_only" ON job_feed_log TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY "admin_read_feed_log" ON job_feed_log FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.id = auth.uid() AND profiles.role = 'support_agent'
+  ));
+
+-- ----------------------------------------------------------------------------
+-- RPC: mark jobs as seen / saved / ignored
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION mark_job_interaction(
+  p_user_id  uuid,
+  p_job_id   uuid,
+  p_action   text  -- 'seen' | 'saved' | 'ignored' | 'applied'
+) RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  INSERT INTO user_job_matches (user_id, job_id, fit_score, is_seen, is_saved, is_ignored, is_applied)
+    VALUES (
+      p_user_id, p_job_id, 0,
+      p_action = 'seen',
+      p_action = 'saved',
+      p_action = 'ignored',
+      p_action = 'applied'
+    )
+  ON CONFLICT (user_id, job_id)
+  DO UPDATE SET
+    is_seen    = CASE WHEN p_action = 'seen'    THEN true ELSE user_job_matches.is_seen END,
+    is_saved   = CASE WHEN p_action = 'saved'   THEN true ELSE user_job_matches.is_saved END,
+    is_ignored = CASE WHEN p_action = 'ignored' THEN true ELSE user_job_matches.is_ignored END,
+    is_applied = CASE WHEN p_action = 'applied' THEN true ELSE user_job_matches.is_applied END,
+    updated_at = now();
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION mark_job_interaction(uuid, uuid, text) TO authenticated, service_role;
+
+COMMENT ON TABLE user_job_matches IS
+  'AI-scored fit results per user/job. Populated by match-jobs edge function. '
+  'Read by discover-jobs for enriched search results.';
+
+COMMENT ON TABLE job_alerts IS
+  'User job alert subscriptions. Processed by job-alerts edge function on schedule.';


### PR DESCRIPTION
## What is this

Builds the full job search agent: live feeds from public APIs → AI scoring → enriched search results.

## New: `match-jobs` edge function

Scores jobs against a user's Career Profile using Claude Haiku:
- Loads skills, target titles, career level, salary expectations
- Cleans job descriptions with `job-parser` (strips benefits/EEO noise first)
- Batches 10 jobs per Claude call for cost efficiency
- Returns: `fit_score`, `skill_gaps`, `matched_skills`, `smart_tag`, `effort_level`, `response_prob`
- Upserts to `user_job_matches` for cached enrichment on future searches

## New: `job-feeds` edge function

5 free public sources, all run in parallel:

| Source | Type | Jobs |
|---|---|---|
| Remotive | JSON API | ~450 remote |
| We Work Remotely | RSS | ~200 remote |
| Arbeitnow | JSON API | ~300 global tech |
| Greenhouse | Public API | 17 companies (Anthropic, Stripe, Vercel...) |
| Lever | Public API | 10 companies (Netflix, Reddit, Coinbase...) |

## Upgraded: `discover-jobs` v6

- Returns AI fit scores, `smart_tag`, `skill_gaps`, `matched_skills` per job
- Hides ignored jobs, filters by `minFitScore`
- Triggers background `match-jobs` when unscored jobs exist
- `matchingTriggered: true` flag so UI can show "Analyzing fit..."

## DB migration

- `user_job_matches` table
- `job_alerts` table  
- `job_feed_log` table
- `mark_job_interaction()` RPC