### PR TITLE
feat(job-search): wire AI scores into UI + live job feeds cron

### DIFF
--- a/.github/workflows/job-feeds.yml
+++ b/.github/workflows/job-feeds.yml
@@ -1,0 +1,41 @@
+name: iCareerOS Job Feeds
+
+# Fetches fresh jobs from Remotive, We Work Remotely, Arbeitnow,
+# Greenhouse boards, and Lever company boards every 2 hours.
+# Runs alongside the existing Python scraper for maximum coverage.
+
+on:
+  schedule:
+    - cron: '30 */2 * * *'   # every 2 hours, offset 30min from job-scraper
+  workflow_dispatch:           # manual trigger via Actions UI
+
+jobs:
+  run-job-feeds:
+    name: Fetch Job Feeds → Supabase
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Invoke job-feeds edge function
+        run: |
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+            "$SUPABASE_URL/functions/v1/job-feeds" \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{"source":"all"}')
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | head -1)
+
+          echo "HTTP status: $HTTP_CODE"
+          echo "Response: $BODY"
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::warning::job-feeds returned $HTTP_CODE"
+          else
+            INGESTED=$(echo "$BODY" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('ingested', 0))" 2>/dev/null || echo "?")
+            echo "✅ Ingested $INGESTED jobs"
+          fi
+        env:
+          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/.github/workflows/migrate-job-search-agent.yml
+++ b/.github/workflows/migrate-job-search-agent.yml
@@ -1,0 +1,54 @@
+name: DB Migration — Job Search Agent Tables
+
+# Applies:
+#   20260501_job_search_agent.sql     (user_job_matches, job_alerts, job_feed_log, RPC)
+#   20260430_domain_extraction_hints.sql  (adaptive scraping cache)
+#   20260430_extraction_cache_rpcs.sql    (counter increment RPCs)
+#
+# Run manually via: Actions → DB Migration — Job Search Agent Tables → Run workflow
+
+on:
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    name: Apply job search agent migrations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply 20260430_domain_extraction_hints
+        run: |
+          SQL=$(cat supabase/migrations/20260430_domain_extraction_hints.sql)
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "https://api.supabase.com/v1/projects/bryoehuhhhjqcueomgev/database/query" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_ACCESS_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": $(echo "$SQL" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          echo "domain_extraction_hints: HTTP $HTTP_CODE"
+          [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]] && echo "✅" || (echo "❌"; exit 1)
+
+      - name: Apply 20260430_extraction_cache_rpcs
+        run: |
+          SQL=$(cat supabase/migrations/20260430_extraction_cache_rpcs.sql)
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "https://api.supabase.com/v1/projects/bryoehuhhhjqcueomgev/database/query" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_ACCESS_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": $(echo "$SQL" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          echo "extraction_cache_rpcs: HTTP $HTTP_CODE"
+          [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]] && echo "✅" || (echo "❌"; exit 1)
+
+      - name: Apply 20260501_job_search_agent
+        run: |
+          SQL=$(cat supabase/migrations/20260501_job_search_agent.sql)
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "https://api.supabase.com/v1/projects/bryoehuhhhjqcueomgev/database/query" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_ACCESS_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": $(echo "$SQL" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          echo "job_search_agent: HTTP $HTTP_CODE"
+          [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]] && echo "✅ All migrations applied" || (echo "❌"; exit 1)

--- a/src/pages/JobSearch.tsx
+++ b/src/pages/JobSearch.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -8,7 +8,7 @@ import {
   Search, Loader2, MapPin, Building2, ExternalLink, Target,
   Briefcase, Plus, X, DollarSign, AlertTriangle, TrendingUp,
   Zap, Shield, Clock, Database, Filter, ShieldCheck, ShieldAlert, ShieldX,
-  EyeOff,
+  EyeOff, Sparkles, CheckCircle, BookOpen, ChevronDown, ChevronUp,
 } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
@@ -17,9 +17,13 @@ import {
   getIgnoredJobs, ignoreJob, isJobIgnored, isJobAlreadySaved, type IgnoredJob,
 } from "@/lib/job-search";
 import { STRATEGY_CONFIG, TRUST_LEVEL_CONFIG, type FakeJobFlag, type HistoricalOutcomes } from "@/lib/job-search/jobQualityEngine";
-import { searchJobs as searchJobsService } from "@/services/job/api";
+import { searchJobs as searchJobsService, pollMatchScores, markJobInteraction } from "@/services/job/api";
 import { scoreJobs, type EnrichedJob } from "@/services/matching/api";
 import type { JobResult, JobSearchFilters } from "@/services/job/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function parseSalaryNumber(salary: string): number | null {
   const match = salary.replace(/,/g, "").match(/(\d+)/g);
@@ -28,10 +32,12 @@ function parseSalaryNumber(salary: string): number | null {
   if (nums.length >= 2) return (nums[0] + nums[1]) / 2;
   return nums[0];
 }
+
 const MARKET_BENCHMARKS: Record<string, number> = {
   "entry": 65000, "junior": 75000, "mid": 105000, "senior": 140000, "lead": 165000,
   "staff": 185000, "principal": 210000, "director": 195000, "vp": 230000,
 };
+
 function estimateMarketRate(title: string): number {
   const lower = title.toLowerCase();
   for (const [key, val] of Object.entries(MARKET_BENCHMARKS)) { if (lower.includes(key)) return val; }
@@ -41,15 +47,33 @@ function estimateMarketRate(title: string): number {
   if (lower.includes("designer")) return 100000;
   return 100000;
 }
+
 function SalaryBadge({ salary, title }: { salary: string; title?: string }) {
   const parsed = parseSalaryNumber(salary);
   if (!parsed) return null;
   const diff = ((parsed - estimateMarketRate(title || "")) / estimateMarketRate(title || "")) * 100;
-  if (diff >= 10) return <Badge variant="outline" className="text-[10px] bg-success/10 text-success border-success/30">↑ Above Market</Badge>;
+  if (diff >= 10) return <Badge variant="outline" className="text-[10px] bg-green-500/10 text-green-600 border-green-300 dark:text-green-400">↑ Above Market</Badge>;
   if (diff <= -10) return <Badge variant="outline" className="text-[10px] bg-destructive/10 text-destructive border-destructive/30">↓ Below Market</Badge>;
   return <Badge variant="outline" className="text-[10px] bg-accent/10 text-accent border-accent/30">≈ Market Rate</Badge>;
 }
-function getSmartTagUI(job: EnrichedJob, prob: number): { label: string; color: string; icon: any } {
+
+// AI smart tag → UI config
+const AI_SMART_TAG_CONFIG: Record<string, { label: string; color: string; icon: any }> = {
+  hot_match:  { label: "Hot Match",         color: "text-green-600 border-green-300 dark:text-green-400 bg-green-500/10", icon: TrendingUp },
+  good_fit:   { label: "Good Fit",          color: "text-primary border-primary/30",                                      icon: Target },
+  stretch:    { label: "Stretch",           color: "text-amber-600 border-amber-300 dark:text-amber-400",                 icon: Zap },
+  reach:      { label: "Reach",             color: "text-orange-600 border-orange-300 dark:text-orange-400",              icon: Shield },
+  low_roi:    { label: "Low ROI",           color: "text-destructive/70 border-destructive/20",                           icon: AlertTriangle },
+  apply_fast: { label: "Apply Fast",        color: "text-orange-600 border-orange-300 dark:text-orange-400",              icon: Zap },
+};
+
+function getSmartTagUI(job: EnrichedJob): { label: string; color: string; icon: any } {
+  // Use AI smart_tag when available
+  if (job.smart_tag && AI_SMART_TAG_CONFIG[job.smart_tag]) {
+    return AI_SMART_TAG_CONFIG[job.smart_tag];
+  }
+  // Fall back to local scoring
+  const prob = job.responseProbability || 0;
   if (job.is_flagged) return { label: "Low Confidence", color: "text-destructive border-destructive/30", icon: AlertTriangle };
   if ((job.effortEstimate || 0) > 70 && prob < 40) return { label: "Low ROI", color: "text-destructive/70 border-destructive/20", icon: AlertTriangle };
   if (prob >= 70) return { label: "High Chance", color: "text-green-600 border-green-300 dark:text-green-400", icon: TrendingUp };
@@ -60,19 +84,197 @@ function getSmartTagUI(job: EnrichedJob, prob: number): { label: string; color: 
   if (prob < 35) return { label: "Improve Resume First", color: "text-amber-600 border-amber-300 dark:text-amber-400", icon: Shield };
   return { label: "Worth Applying", color: "text-primary border-primary/30", icon: Target };
 }
-function getJobSaveKey(job: { url?: string; title: string; company: string }): string {
-  return (job.url || "").trim().toLowerCase() + "|" + job.title.trim().toLowerCase() + "|" + job.company.trim().toLowerCase();
+
+function getFitScoreColor(score: number): string {
+  if (score >= 80) return "text-green-600 dark:text-green-400";
+  if (score >= 60) return "text-amber-600 dark:text-amber-400";
+  return "text-destructive";
 }
+
+function getFitScoreBg(score: number): string {
+  if (score >= 80) return "bg-green-500/10 border-green-300/50";
+  if (score >= 60) return "bg-amber-500/10 border-amber-300/50";
+  return "bg-destructive/10 border-destructive/30";
+}
+
 function getProbColor(prob: number) {
   if (prob >= 70) return "text-green-600 dark:text-green-400";
   if (prob >= 50) return "text-amber-600 dark:text-amber-400";
   return "text-destructive";
 }
+
+function getJobSaveKey(job: { url?: string; title: string; company: string }): string {
+  return (job.url || "").trim().toLowerCase() + "|" + job.title.trim().toLowerCase() + "|" + job.company.trim().toLowerCase();
+}
+
 const JOB_TYPE_OPTIONS = ["remote", "hybrid", "in-office", "full-time", "part-time", "contract", "short-term"];
 const PAGE_SIZE = 50;
 
+// ---------------------------------------------------------------------------
+// Job card sub-component
+// ---------------------------------------------------------------------------
+
+function JobCard({
+  job, onSave, onAnalyze, onIgnore, onApply, isSaving,
+}: {
+  job: EnrichedJob;
+  onSave: () => void;
+  onAnalyze: () => void;
+  onIgnore: () => void;
+  onApply: () => void;
+  isSaving: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const hasAiScore = job.fit_score != null;
+  const displayProb = hasAiScore ? (job.response_prob ?? job.responseProbability ?? 0) : (job.responseProbability ?? 0);
+  const tag = getSmartTagUI(job);
+  const TagIcon = tag.icon;
+  const trustCfg = job.trustLevel ? TRUST_LEVEL_CONFIG[job.trustLevel] : TRUST_LEVEL_CONFIG.trusted;
+  const TrustIcon = trustCfg.icon === "shield-check" ? ShieldCheck : trustCfg.icon === "shield-alert" ? ShieldAlert : ShieldX;
+  const hasFlags = job.flags && job.flags.length > 0;
+  const hasDanger = job.flags?.some(f => f.severity === "danger");
+  const hasSkillData = (job.matched_skills?.length ?? 0) > 0 || (job.skill_gaps?.length ?? 0) > 0;
+  const daysAgo = job.first_seen_at ? Math.round((Date.now() - new Date(job.first_seen_at).getTime()) / (1000 * 60 * 60 * 24)) : null;
+
+  return (
+    <Card className={"p-5 transition-all " + (hasDanger ? "border-destructive/30 bg-destructive/5" : hasFlags ? "border-warning/30 bg-warning/5" : "hover:border-accent/50")}>
+      <div className="flex flex-col sm:flex-row sm:items-start gap-4">
+
+        {/* ── Main content ── */}
+        <div className="flex-1 min-w-0">
+
+          {/* Title row */}
+          <div className="flex items-start gap-2 mb-1">
+            <h3 className="font-semibold text-foreground text-lg leading-tight">{job.title}</h3>
+            {hasDanger && <AlertTriangle className="w-4 h-4 text-destructive flex-shrink-0 mt-1" />}
+          </div>
+
+          {/* Meta row */}
+          <div className="flex flex-wrap items-center gap-3 mt-1 text-sm text-muted-foreground">
+            <span className="flex items-center gap-1"><Building2 className="w-3.5 h-3.5" /> {job.company}</span>
+            <span className="flex items-center gap-1"><MapPin className="w-3.5 h-3.5" /> {job.location}</span>
+            {job.type && <Badge variant="outline" className="capitalize text-xs"><Briefcase className="w-3 h-3 mr-1" />{job.type}</Badge>}
+            {job.salary && <span className="flex items-center gap-1"><Badge variant="outline" className="text-xs"><DollarSign className="w-3 h-3 mr-1" />{job.salary}</Badge><SalaryBadge salary={job.salary} title={job.title} /></span>}
+            {job.source && <Badge variant="outline" className="text-xs capitalize">{job.source.split(":")[0]}</Badge>}
+            {daysAgo !== null && <span className="text-xs text-muted-foreground flex items-center gap-1"><Clock className="w-3 h-3" />{daysAgo}d ago</span>}
+          </div>
+
+          {/* Description (collapsible) */}
+          <p className={"text-sm text-muted-foreground mt-2 leading-relaxed " + (expanded ? "" : "line-clamp-3")}>
+            {job.description}
+          </p>
+
+          {/* AI score + tags row */}
+          <div className="flex flex-wrap items-center gap-3 mt-3">
+            {hasAiScore && (
+              <div className={"flex items-center gap-1.5 rounded-lg border px-2.5 py-1 " + getFitScoreBg(job.fit_score!)}>
+                <Sparkles className={"w-3.5 h-3.5 " + getFitScoreColor(job.fit_score!)} />
+                <span className={"text-sm font-bold " + getFitScoreColor(job.fit_score!)}>{job.fit_score}% fit</span>
+              </div>
+            )}
+            <div className="flex items-center gap-1">
+              <TrustIcon className={"w-3.5 h-3.5 " + trustCfg.colorClass} />
+              <span className={"text-xs font-semibold " + trustCfg.colorClass}>{trustCfg.label}</span>
+            </div>
+            <Badge variant="outline" className={"text-xs " + tag.color}><TagIcon className="w-3 h-3 mr-1" />{tag.label}</Badge>
+            {displayProb > 0 && (
+              <span className={"text-sm font-semibold " + getProbColor(displayProb)}>{displayProb}% response prob.</span>
+            )}
+          </div>
+
+          {/* AI skill breakdown (expandable) */}
+          {hasSkillData && (
+            <div className="mt-3">
+              <button
+                onClick={() => setExpanded(!expanded)}
+                className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {expanded ? <ChevronUp className="w-3.5 h-3.5" /> : <ChevronDown className="w-3.5 h-3.5" />}
+                {expanded ? "Hide" : "Show"} AI skill analysis
+              </button>
+
+              {expanded && (
+                <div className="mt-2 space-y-2">
+                  {(job.matched_skills?.length ?? 0) > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold text-green-600 dark:text-green-400 mb-1 flex items-center gap-1">
+                        <CheckCircle className="w-3 h-3" /> Skills you have ({job.matched_skills!.length})
+                      </p>
+                      <div className="flex flex-wrap gap-1">
+                        {job.matched_skills!.map((s, i) => (
+                          <Badge key={i} variant="outline" className="text-[10px] bg-green-500/10 text-green-600 border-green-300/50 dark:text-green-400">{s}</Badge>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {(job.skill_gaps?.length ?? 0) > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold text-amber-600 dark:text-amber-400 mb-1 flex items-center gap-1">
+                        <BookOpen className="w-3 h-3" /> Skills to develop ({job.skill_gaps!.length})
+                      </p>
+                      <div className="flex flex-wrap gap-1">
+                        {job.skill_gaps!.map((s, i) => (
+                          <Badge key={i} variant="outline" className="text-[10px] bg-amber-500/10 text-amber-600 border-amber-300/50 dark:text-amber-400">{s}</Badge>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {job.match_summary && (
+                    <p className="text-xs text-muted-foreground italic mt-1">💡 {job.match_summary}</p>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Flags */}
+          {hasFlags && (
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {job.flags!.map((flag, fi) => (
+                <Badge key={fi} variant="outline" className={"text-[10px] " + (flag.severity === "danger" ? "border-destructive/40 text-destructive bg-destructive/5" : "border-warning/40 text-warning bg-warning/5")}>
+                  <AlertTriangle className="w-3 h-3 mr-1" />{flag.label}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          {/* Match reason (non-AI) */}
+          {!hasAiScore && job.matchReason && !hasDanger && (
+            <p className="text-xs text-accent mt-2 italic">💡 {job.matchReason}</p>
+          )}
+        </div>
+
+        {/* ── Action buttons ── */}
+        <div className="flex sm:flex-col gap-2 flex-shrink-0">
+          <Button variant="outline" size="sm" className="text-xs" onClick={onSave} disabled={isSaving}>
+            {isSaving ? <><Loader2 className="w-3.5 h-3.5 mr-1 animate-spin" />Saving</> : <><Plus className="w-3.5 h-3.5 mr-1" />Save</>}
+          </Button>
+          <Button size="sm" className="gradient-indigo text-white text-xs" onClick={onAnalyze}>
+            <Target className="w-3.5 h-3.5 mr-1" />Check Fit
+          </Button>
+          {job.url && (
+            <Button variant="outline" size="sm" className="text-xs" onClick={onApply}>
+              <ExternalLink className="w-3.5 h-3.5 mr-1" />Apply
+            </Button>
+          )}
+          <Button variant="ghost" size="sm" className="text-xs text-muted-foreground hover:text-destructive" onClick={onIgnore}>
+            <EyeOff className="w-3.5 h-3.5 mr-1" />Ignore
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
 export default function JobSearchPage() {
   const navigate = useNavigate();
+
+  // Filters
   const [skills, setSkills] = useState<string[]>([]);
   const [jobTypes, setJobTypes] = useState<string[]>([]);
   const [location, setLocation] = useState("");
@@ -82,22 +284,28 @@ export default function JobSearchPage() {
   const [titleInput, setTitleInput] = useState("");
   const [salaryMin, setSalaryMin] = useState("");
   const [salaryMax, setSalaryMax] = useState("");
-  const [jobs, setJobs] = useState<EnrichedJob[]>([]);
-  const [citations, setCitations] = useState<string[]>([]);
-  const [searching, setSearching] = useState(false);
-  const [profileLoaded, setProfileLoaded] = useState(false);
-  const [searchSource, setSearchSource] = useState<"all" | "ai" | "database">("database");
-  const [sortBy, setSortBy] = useState<"relevance" | "probability" | "newest" | "decision">("decision");
+  const [minFitScore, setMinFitScore] = useState(60);
+  const [searchMode, setSearchMode] = useState<"quality" | "balanced" | "volume">("balanced");
+  const [daysOld, setDaysOld] = useState(0);
   const [showFlagged, setShowFlagged] = useState(true);
+
+  // Results
+  const [jobs, setJobs] = useState<EnrichedJob[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [matchingInProgress, setMatchingInProgress] = useState(false);
+  const [totalBeforeFilter, setTotalBeforeFilter] = useState(0);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [sortBy, setSortBy] = useState<"relevance" | "probability" | "newest" | "decision" | "fit_score">("fit_score");
+
+  // Profile + history
+  const [profileLoaded, setProfileLoaded] = useState(false);
   const [historicalOutcomes, setHistoricalOutcomes] = useState<HistoricalOutcomes | undefined>();
   const [savingJobKeys, setSavingJobKeys] = useState<Record<string, boolean>>({});
   const [ignoredList, setIgnoredList] = useState<IgnoredJob[]>([]);
   const [savedApps, setSavedApps] = useState<{ job_title: string; company: string; job_url: string | null }[]>([]);
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
-  const [minFitScore, setMinFitScore] = useState(60);
-  const [searchMode, setSearchMode] = useState<"quality" | "balanced" | "volume">("balanced");
-  const [totalBeforeFilter, setTotalBeforeFilter] = useState(0);
-  const [daysOld, setDaysOld] = useState(0);
+
+  // Polling ref for background match scores
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => { loadProfile(); loadIgnoredAndSaved(); }, []);
 
@@ -106,6 +314,9 @@ export default function JobSearchPage() {
     if (skills.length > 0 || targetTitles.length > 0) handleSearch();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profileLoaded]);
+
+  // Cleanup poll timer on unmount
+  useEffect(() => () => { if (pollTimerRef.current) clearTimeout(pollTimerRef.current); }, []);
 
   const loadIgnoredAndSaved = async () => {
     const [ignored, { data: { session } }] = await Promise.all([getIgnoredJobs(), supabase.auth.getSession()]);
@@ -133,7 +344,7 @@ export default function JobSearchPage() {
         if (data.salary_min) setSalaryMin(data.salary_min);
         if (data.salary_max) setSalaryMax(data.salary_max);
         if (data.min_match_score != null) setMinFitScore(data.min_match_score);
-        if (data.search_mode) setSearchMode(data.search_mode as "quality" | "balanced" | "volume");
+        if (data.search_mode) setSearchMode(data.search_mode as any);
       }
       if (appData && appData.length >= 3) {
         const total = appData.length;
@@ -149,42 +360,129 @@ export default function JobSearchPage() {
   const toggleJobType = (type: string) => setJobTypes(prev => prev.includes(type) ? prev.filter(t => t !== type) : [...prev, type]);
 
   const handleSearch = async (overrideFilters?: Partial<JobSearchFilters>) => {
-    setSearching(true); setJobs([]); setCitations([]);
+    if (pollTimerRef.current) { clearTimeout(pollTimerRef.current); pollTimerRef.current = null; }
+    setSearching(true);
+    setJobs([]);
+    setMatchingInProgress(false);
+
     const filters: JobSearchFilters = {
       skills, jobTypes, location, query: customQuery, careerLevel,
-      targetTitles, salaryMin, salaryMax, searchSource, minFitScore, showFlagged,
-      search_mode: searchMode, days_old: daysOld,
+      targetTitles, salaryMin, salaryMax, searchSource: "database",
+      minFitScore, showFlagged, search_mode: searchMode, days_old: daysOld,
       ...overrideFilters,
     };
-    let rawJobs: JobResult[] = [], cits: string[] = [];
+
+    let rawJobs: JobResult[] = [];
+    let triggeredMatch = false;
+
     try {
       const result = await searchJobsService(filters);
-      rawJobs = result.jobs; cits = result.citations;
-    } catch (e) { console.error("[JobSearch] error:", e); toast.error("Search encountered an issue."); }
+      rawJobs = result.jobs;
+      triggeredMatch = result.matchingTriggered ?? false;
+    } catch (e) {
+      console.error("[JobSearch] error:", e);
+      toast.error("Search encountered an issue.");
+    }
 
-    let filtered = rawJobs.filter(job => !isJobIgnored(job, ignoredList)).filter(job => !isJobAlreadySaved(job, savedApps));
+    // Filter out ignored / already-saved
+    let filtered = rawJobs
+      .filter(job => !isJobIgnored(job, ignoredList))
+      .filter(job => !isJobAlreadySaved(job, savedApps));
+
+    // Local enrichment (for jobs without AI scores)
     let enriched: EnrichedJob[];
     try {
       enriched = scoreJobs({ jobs: filtered, skills, historicalOutcomes, salaryMin, salaryMax, remotePreferred: jobTypes.includes("remote") });
-    } catch (e) {
-      enriched = filtered.map(job => ({ ...job, flags: [], trustScore: 50, trustLevel: "caution" as const, strategy: "apply_now" as const, responseProbability: 50, decisionScore: job.quality_score || 50, effortEstimate: 50, smartTag: "Worth Applying" }));
+    } catch {
+      enriched = filtered.map(job => ({ ...job, flags: [], trustScore: 50, trustLevel: "caution" as const, strategy: "apply_now" as const, responseProbability: 50, decisionScore: job.quality_score || 50, effortEstimate: 50 }));
     }
-    if (sortBy === "decision") enriched.sort((a, b) => (b.decisionScore || 0) - (a.decisionScore || 0));
-    else if (sortBy === "probability") enriched.sort((a, b) => (b.responseProbability || 0) - (a.responseProbability || 0));
-    else if (sortBy === "newest") enriched.sort((a, b) => { if (!a.first_seen_at && !b.first_seen_at) return 0; if (!a.first_seen_at) return 1; if (!b.first_seen_at) return -1; return new Date(b.first_seen_at).getTime() - new Date(a.first_seen_at).getTime(); });
-    if (!showFlagged) enriched = enriched.filter(j => !j.is_flagged);
+
+    // Sort
+    enriched = sortResults(enriched, sortBy);
+
+    // Filter by fit score (use AI score when available, local score otherwise)
     const effectiveMinFit = overrideFilters?.minFitScore ?? minFitScore;
-    const beforeFilterCount = enriched.length;
-    enriched = enriched.filter(j => (j.decisionScore || 0) >= effectiveMinFit);
-    setTotalBeforeFilter(beforeFilterCount); setJobs(enriched); setCitations(cits); setVisibleCount(PAGE_SIZE);
-    if (!enriched.length && beforeFilterCount > 0) toast.info(beforeFilterCount + " jobs found but hidden by your " + effectiveMinFit + "% fit score filter.");
-    else if (!enriched.length && rawJobs.length > 0) toast.info("Jobs found but all filtered out.");
-    else if (!enriched.length) toast.info("No jobs found. Try adjusting your criteria.");
+    const beforeCount = enriched.length;
+    if (effectiveMinFit > 0) {
+      enriched = enriched.filter(j => {
+        const score = j.fit_score ?? j.decisionScore ?? 0;
+        return score >= effectiveMinFit;
+      });
+    }
+    if (!showFlagged) enriched = enriched.filter(j => !j.is_flagged);
+
+    setTotalBeforeFilter(beforeCount);
+    setJobs(enriched);
+    setVisibleCount(PAGE_SIZE);
+    setMatchingInProgress(triggeredMatch);
+
+    if (!enriched.length && beforeCount > 0) {
+      toast.info(`${beforeCount} jobs found but hidden by your ${effectiveMinFit}% fit score filter.`);
+    } else if (!enriched.length && rawJobs.length > 0) {
+      toast.info("Jobs found but all filtered out.");
+    } else if (!enriched.length) {
+      toast.info("No jobs found. Try adjusting your criteria.");
+    }
+
     setSearching(false);
+
+    // Schedule poll for AI scores if match was triggered
+    if (triggeredMatch && enriched.length > 0) {
+      schedulePollForScores(enriched.map(j => j.id).filter(Boolean) as string[]);
+    }
+  };
+
+  // Poll for AI match scores every 5 seconds while matching is in progress
+  const schedulePollForScores = (jobIds: string[]) => {
+    if (!jobIds.length) return;
+    pollTimerRef.current = setTimeout(async () => {
+      const scoreMap = await pollMatchScores(jobIds);
+      if (scoreMap.size > 0) {
+        setJobs(prev => {
+          const updated = prev.map(j => {
+            const scores = j.id ? scoreMap.get(j.id) : undefined;
+            return scores ? { ...j, ...scores } : j;
+          });
+          return sortResults(updated, sortBy);
+        });
+        // Check if all jobs are now scored
+        const allScored = jobIds.every(id => scoreMap.has(id));
+        if (!allScored) {
+          schedulePollForScores(jobIds.filter(id => !scoreMap.has(id)));
+        } else {
+          setMatchingInProgress(false);
+          toast.success("AI fit scores ready — jobs re-ranked by match quality.");
+        }
+      } else {
+        // Still waiting — poll again
+        schedulePollForScores(jobIds);
+      }
+    }, 5_000);
+  };
+
+  const sortResults = (list: EnrichedJob[], by: string): EnrichedJob[] => {
+    const sorted = [...list];
+    if (by === "fit_score" || by === "decision") {
+      sorted.sort((a, b) => {
+        const sa = a.fit_score ?? a.decisionScore ?? 0;
+        const sb = b.fit_score ?? b.decisionScore ?? 0;
+        return sb - sa;
+      });
+    } else if (by === "probability") {
+      sorted.sort((a, b) => (b.response_prob ?? b.responseProbability ?? 0) - (a.response_prob ?? a.responseProbability ?? 0));
+    } else if (by === "newest") {
+      sorted.sort((a, b) => {
+        if (!a.first_seen_at && !b.first_seen_at) return 0;
+        if (!a.first_seen_at) return 1;
+        if (!b.first_seen_at) return -1;
+        return new Date(b.first_seen_at).getTime() - new Date(a.first_seen_at).getTime();
+      });
+    }
+    return sorted;
   };
 
   const handleAnalyzeFit = (job: EnrichedJob) => {
-    const jobDesc = job.title + " at " + job.company + "\nLocation: " + job.location + "\nType: " + job.type + (job.salary ? "\nSalary: " + job.salary : "") + "\n\n" + job.description;
+    const jobDesc = `${job.title} at ${job.company}\nLocation: ${job.location}\nType: ${job.type}${job.salary ? "\nSalary: " + job.salary : ""}\n\n${job.description}`;
     navigate("/job-seeker", { state: { prefillJob: jobDesc, prefillJobLink: job.url || "", fromSearch: true } });
   };
 
@@ -196,66 +494,112 @@ export default function JobSearchPage() {
       const result = await saveJobToApplications({ title: job.title, company: job.company, url: job.url, description: job.description, location: job.location, type: job.type });
       if (!result.ok) { toast.error(result.error || "Failed to save job"); return; }
       if (result.alreadySaved) { toast.info("Job already saved"); return; }
+      if (job.id) markJobInteraction(job.id, "saved").catch(() => {});
       toast.success("Job saved to Applications");
-    } finally { setSavingJobKeys(prev => ({ ...prev, [saveKey]: false })); }
+    } finally {
+      setSavingJobKeys(prev => ({ ...prev, [saveKey]: false }));
+    }
   };
+
+  const handleIgnoreJob = async (job: EnrichedJob) => {
+    const saveKey = getJobSaveKey(job);
+    const ok = await ignoreJob({ title: job.title, company: job.company, url: job.url });
+    if (ok) {
+      if (job.id) markJobInteraction(job.id, "ignored").catch(() => {});
+      setJobs(prev => prev.filter(j => getJobSaveKey(j) !== saveKey));
+      setIgnoredList(prev => [...prev, { id: "", job_title: job.title, company: job.company, job_url: job.url }]);
+      toast.success("Job hidden");
+    }
+  };
+
+  const handleApplyJob = (job: EnrichedJob) => {
+    if (job.url) {
+      window.open(job.url, "_blank", "noopener,noreferrer");
+      if (job.id) markJobInteraction(job.id, "applied").catch(() => {});
+    }
+  };
+
+  const visibleJobs = jobs.filter(j => showFlagged || !j.is_flagged);
+  const aiScoredCount = jobs.filter(j => j.fit_score != null).length;
 
   return (
     <div className="bg-background">
       <div className="max-w-5xl mx-auto px-6 py-10">
+
+        {/* Header */}
         <div className="text-center mb-10">
-          <h1 className="font-display text-4xl font-bold text-primary mb-3">Jobs that <span className="text-gradient-indigo">get you interviews</span></h1>
-          <p className="text-muted-foreground text-lg max-w-xl mx-auto">AI finds the best opportunities and shows your interview probability for each one.</p>
+          <h1 className="font-display text-4xl font-bold text-primary mb-3">
+            Jobs that <span className="text-gradient-indigo">get you interviews</span>
+          </h1>
+          <p className="text-muted-foreground text-lg max-w-xl mx-auto">
+            AI scores every job against your profile — so you focus on the ones worth applying to.
+          </p>
         </div>
+
+        {/* Filters card */}
         <Card className="p-6 mb-8">
           <div className="space-y-4">
             <div>
-              <label className="text-sm font-semibold text-foreground mb-2 block">Search Source</label>
-              <div className="flex gap-2">
-                <Badge variant="default" className="bg-primary text-primary-foreground">
-                  <Database className="w-3 h-3 mr-1" />Job Database
-                </Badge>
-              </div>
+              <label className="text-sm font-semibold text-foreground mb-2 block">Source</label>
+              <Badge variant="default" className="bg-primary text-primary-foreground"><Database className="w-3 h-3 mr-1" />Live Job Database</Badge>
             </div>
+
+            {/* Target titles */}
             <div>
               <label className="text-sm font-semibold text-foreground mb-2 block">Target Job Titles</label>
               <div className="flex gap-2 mb-2">
-                <Input value={titleInput} onChange={e => setTitleInput(e.target.value)} placeholder="e.g. Software Engineer" onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); const t = titleInput.trim(); if (t && !targetTitles.includes(t)) { setTargetTitles([...targetTitles, t]); setTitleInput(""); } } }} />
+                <Input value={titleInput} onChange={e => setTitleInput(e.target.value)} placeholder="e.g. Software Engineer"
+                  onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); const t = titleInput.trim(); if (t && !targetTitles.includes(t)) { setTargetTitles([...targetTitles, t]); setTitleInput(""); } } }} />
                 <Button variant="outline" size="sm" onClick={() => { const t = titleInput.trim(); if (t && !targetTitles.includes(t)) { setTargetTitles([...targetTitles, t]); setTitleInput(""); } }}><Plus className="w-4 h-4" /></Button>
               </div>
-              <div className="flex flex-wrap gap-2">{targetTitles.map((t, i) => <Badge key={i} variant="secondary" className="cursor-pointer" onClick={() => setTargetTitles(targetTitles.filter((_, idx) => idx !== i))}>{t} <X className="w-3 h-3 ml-1" /></Badge>)}</div>
+              <div className="flex flex-wrap gap-2">
+                {targetTitles.map((t, i) => <Badge key={i} variant="secondary" className="cursor-pointer" onClick={() => setTargetTitles(targetTitles.filter((_, idx) => idx !== i))}>{t} <X className="w-3 h-3 ml-1" /></Badge>)}
+              </div>
             </div>
+
+            {/* Career level */}
             <div>
-              <label className="text-sm font-semibold text-foreground mb-2 block">Career Level <span className="text-xs text-muted-foreground font-normal">(select multiple)</span></label>
+              <label className="text-sm font-semibold text-foreground mb-2 block">Career Level</label>
               <div className="flex flex-wrap gap-2">
                 {["Entry-Level / Junior","Mid-Level","Senior","Manager","Director","VP / Senior Leadership","C-Level / Executive"].map(level => {
                   const levels = careerLevel ? careerLevel.split(", ").filter(Boolean) : [];
                   const isSelected = levels.includes(level);
-                  return <Badge key={level} variant={isSelected ? "default" : "outline"} className={"cursor-pointer text-xs " + (isSelected ? "bg-primary text-primary-foreground" : "hover:bg-accent/10")} onClick={() => { const nl = isSelected ? levels.filter(l => l !== level) : [...levels, level]; setCareerLevel(nl.join(", ")); }}>{level}</Badge>;
+                  return <Badge key={level} variant={isSelected ? "default" : "outline"} className={"cursor-pointer text-xs " + (isSelected ? "bg-primary text-primary-foreground" : "hover:bg-accent/10")}
+                    onClick={() => { const nl = isSelected ? levels.filter(l => l !== level) : [...levels, level]; setCareerLevel(nl.join(", ")); }}>{level}</Badge>;
                 })}
               </div>
             </div>
+
+            {/* Skills */}
             <div>
               <label className="text-sm font-semibold text-foreground mb-2 block">Your Skills</label>
-              {skills.length > 0 ? <div className="flex flex-wrap gap-2">{skills.map((s, i) => <Badge key={i} variant="secondary">{s}</Badge>)}</div>
-                : <p className="text-sm text-muted-foreground">No skills loaded. <button className="text-accent hover:underline" onClick={() => navigate("/profile")}>Add skills</button></p>}
+              {skills.length > 0
+                ? <div className="flex flex-wrap gap-2">{skills.map((s, i) => <Badge key={i} variant="secondary">{s}</Badge>)}</div>
+                : <p className="text-sm text-muted-foreground">No skills loaded. <button className="text-accent hover:underline" onClick={() => navigate("/profile")}>Add skills to profile</button></p>
+              }
             </div>
+
+            {/* Job type */}
             <div>
               <label className="text-sm font-semibold text-foreground mb-2 block">Job Type</label>
               <div className="flex flex-wrap gap-2">
                 {JOB_TYPE_OPTIONS.map(type => <Badge key={type} variant={jobTypes.includes(type) ? "default" : "outline"} className={"cursor-pointer capitalize " + (jobTypes.includes(type) ? "bg-primary text-primary-foreground" : "hover:bg-accent/10")} onClick={() => toggleJobType(type)}>{type}</Badge>)}
               </div>
             </div>
+
+            {/* Location + query */}
             <div className="grid sm:grid-cols-2 gap-4">
               <div>
                 <label className="text-sm font-semibold text-foreground mb-1 block">Location</label>
-                <div className="flex items-center gap-2"><MapPin className="w-4 h-4 text-muted-foreground" /><Input value={location} onChange={e => setLocation(e.target.value)} placeholder="e.g. Remote, London, Berlin" /></div>
+                <div className="flex items-center gap-2"><MapPin className="w-4 h-4 text-muted-foreground" /><Input value={location} onChange={e => setLocation(e.target.value)} placeholder="e.g. Remote, New York" /></div>
               </div>
               <div>
-                <label className="text-sm font-semibold text-foreground mb-1 block">Additional Criteria</label>
+                <label className="text-sm font-semibold text-foreground mb-1 block">Additional Keywords</label>
                 <Input value={customQuery} onChange={e => setCustomQuery(e.target.value)} placeholder="e.g. startup, Fortune 500..." />
               </div>
             </div>
+
+            {/* Posted within + search mode */}
             <div className="grid sm:grid-cols-2 gap-4">
               <div>
                 <label className="text-sm font-semibold text-foreground mb-1 block">Posted Within</label>
@@ -266,46 +610,81 @@ export default function JobSearchPage() {
                   <option value={7}>Last week</option>
                   <option value={14}>Last 2 weeks</option>
                   <option value={30}>Last month</option>
-                  <option value={90}>Last 3 months</option>
                 </select>
               </div>
               <div>
                 <label className="text-sm font-semibold text-foreground mb-1 block">Search Mode</label>
-                <select className="w-full text-sm bg-background border border-input rounded-md px-3 py-2 text-foreground" value={searchMode} onChange={e => setSearchMode(e.target.value as "quality" | "balanced" | "volume")}>
-                  <option value="quality">Quality (top 200)</option>
-                  <option value="balanced">Balanced (top 200)</option>
-                  <option value="volume">Volume (up to 800)</option>
+                <select className="w-full text-sm bg-background border border-input rounded-md px-3 py-2 text-foreground" value={searchMode} onChange={e => setSearchMode(e.target.value as any)}>
+                  <option value="quality">Quality (top 100)</option>
+                  <option value="balanced">Balanced (top 100)</option>
+                  <option value="volume">Volume (top 200)</option>
                 </select>
               </div>
             </div>
+
+            {/* Fit score slider */}
             <div>
-              <label className="text-sm font-semibold text-foreground mb-2 block">Minimum Fit Score: <span className="text-accent font-bold">{minFitScore}%</span></label>
-              <p className="text-xs text-muted-foreground mb-2">Only show jobs with a decision score at or above this threshold</p>
+              <label className="text-sm font-semibold text-foreground mb-2 block">
+                Minimum Fit Score: <span className="text-accent font-bold">{minFitScore}%</span>
+              </label>
+              <p className="text-xs text-muted-foreground mb-2">Hide jobs below this AI fit score threshold</p>
               <div className="flex items-center gap-3">
                 <input type="range" min={0} max={100} value={minFitScore} onChange={e => setMinFitScore(Number(e.target.value))} className="flex-1 accent-[hsl(var(--accent))]" />
                 <Input type="number" min={0} max={100} value={minFitScore} onChange={e => setMinFitScore(Math.max(0, Math.min(100, Number(e.target.value))))} className="w-20 h-8 text-xs" />
               </div>
             </div>
+
+            {/* Salary */}
             <div className="grid sm:grid-cols-2 gap-4">
               <div><label className="text-sm font-semibold text-foreground mb-1 block">Min Salary</label><div className="flex items-center gap-1"><DollarSign className="w-4 h-4 text-muted-foreground" /><Input value={salaryMin} onChange={e => setSalaryMin(e.target.value)} placeholder="80,000" /></div></div>
               <div><label className="text-sm font-semibold text-foreground mb-1 block">Max Salary</label><div className="flex items-center gap-1"><DollarSign className="w-4 h-4 text-muted-foreground" /><Input value={salaryMax} onChange={e => setSalaryMax(e.target.value)} placeholder="150,000" /></div></div>
             </div>
+
             <Button className="gradient-indigo text-white shadow-indigo-500/20 hover:opacity-90 w-full sm:w-auto" disabled={searching} onClick={() => handleSearch()}>
               {searching ? <><Loader2 className="w-4 h-4 animate-spin mr-2" />Searching...</> : <><Search className="w-4 h-4 mr-2" />Search Jobs</>}
             </Button>
           </div>
         </Card>
+
+        {/* AI matching in progress banner */}
+        {matchingInProgress && (
+          <div className="mb-4 flex items-center gap-3 rounded-lg border border-primary/30 bg-primary/5 px-4 py-3">
+            <Sparkles className="w-4 h-4 text-primary animate-pulse flex-shrink-0" />
+            <div className="flex-1">
+              <p className="text-sm font-medium text-primary">Analyzing your fit score for each job…</p>
+              <p className="text-xs text-muted-foreground">Results are re-ranking as AI scores come in. {aiScoredCount > 0 ? `${aiScoredCount} scored so far.` : ""}</p>
+            </div>
+            <Loader2 className="w-4 h-4 animate-spin text-primary flex-shrink-0" />
+          </div>
+        )}
+
+        {/* Results header */}
         {jobs.length > 0 && (
           <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
-            <h2 className="font-display font-bold text-primary text-xl">{jobs.length} Jobs Found</h2>
+            <div>
+              <h2 className="font-display font-bold text-primary text-xl">{visibleJobs.length} Jobs</h2>
+              {aiScoredCount > 0 && (
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  <Sparkles className="w-3 h-3 inline mr-1 text-primary" />
+                  {aiScoredCount} AI-scored
+                </p>
+              )}
+            </div>
             <div className="flex items-center gap-3">
               <div className="flex items-center gap-2">
                 <Filter className="w-4 h-4 text-muted-foreground" />
-                <select className="text-sm bg-card border border-input rounded-md px-2 py-1 text-foreground" value={sortBy} onChange={e => { setSortBy(e.target.value as any); setVisibleCount(PAGE_SIZE); setJobs(prev => { const s = [...prev]; if (e.target.value === "decision") s.sort((a,b) => (b.decisionScore||0)-(a.decisionScore||0)); else if (e.target.value === "probability") s.sort((a,b) => (b.responseProbability||0)-(a.responseProbability||0)); else if (e.target.value === "newest") s.sort((a,b) => { if (!a.first_seen_at&&!b.first_seen_at) return 0; if (!a.first_seen_at) return 1; if (!b.first_seen_at) return -1; return new Date(b.first_seen_at).getTime()-new Date(a.first_seen_at).getTime(); }); return s; }); }}>
-                  <option value="decision">Decision Score</option>
-                  <option value="relevance">Relevance</option>
+                <select className="text-sm bg-card border border-input rounded-md px-2 py-1 text-foreground"
+                  value={sortBy}
+                  onChange={e => {
+                    const v = e.target.value as any;
+                    setSortBy(v);
+                    setJobs(prev => sortResults([...prev], v));
+                    setVisibleCount(PAGE_SIZE);
+                  }}>
+                  <option value="fit_score">AI Fit Score</option>
                   <option value="probability">Response Probability</option>
                   <option value="newest">Newest First</option>
+                  <option value="decision">Decision Score</option>
                 </select>
               </div>
               <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
@@ -314,69 +693,50 @@ export default function JobSearchPage() {
             </div>
           </div>
         )}
+
+        {/* Job cards */}
         <div className="space-y-4">
-          {jobs.filter(j => showFlagged || !j.is_flagged).slice(0, visibleCount).map((job, i) => {
-            const prob = job.responseProbability || 0;
-            const tag = getSmartTagUI(job, prob);
-            const TagIcon = tag.icon;
-            const trustCfg = job.trustLevel ? TRUST_LEVEL_CONFIG[job.trustLevel] : TRUST_LEVEL_CONFIG.trusted;
-            const TrustIcon = trustCfg.icon === "shield-check" ? ShieldCheck : trustCfg.icon === "shield-alert" ? ShieldAlert : ShieldX;
-            const hasFlags = job.flags && job.flags.length > 0;
-            const hasDanger = job.flags?.some(f => f.severity === "danger");
+          {visibleJobs.slice(0, visibleCount).map((job, i) => {
             const saveKey = getJobSaveKey(job);
             return (
-              <Card key={job.id || i} className={"p-5 transition-colors " + (hasDanger ? "border-destructive/30 bg-destructive/5" : hasFlags ? "border-warning/30 bg-warning/5" : "hover:border-accent/50")}>
-                <div className="flex flex-col sm:flex-row sm:items-start gap-4">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-start gap-2 mb-1">
-                      <h3 className="font-semibold text-foreground text-lg">{job.title}</h3>
-                      {hasDanger && <AlertTriangle className="w-4 h-4 text-destructive flex-shrink-0 mt-1" />}
-                    </div>
-                    <div className="flex flex-wrap items-center gap-3 mt-1 text-sm text-muted-foreground">
-                      <span className="flex items-center gap-1"><Building2 className="w-3.5 h-3.5" /> {job.company}</span>
-                      <span className="flex items-center gap-1"><MapPin className="w-3.5 h-3.5" /> {job.location}</span>
-                      {job.type && <Badge variant="outline" className="capitalize text-xs"><Briefcase className="w-3 h-3 mr-1" />{job.type}</Badge>}
-                      {job.salary && <span className="flex items-center gap-1"><Badge variant="outline" className="text-xs"><DollarSign className="w-3 h-3 mr-1" />{job.salary}</Badge><SalaryBadge salary={job.salary} title={job.title} /></span>}
-                      {job.source && <Badge variant="outline" className="text-xs capitalize">{job.source}</Badge>}
-                    </div>
-                    <p className="text-sm text-muted-foreground mt-2 leading-relaxed line-clamp-3">{job.description}</p>
-                    <div className="flex flex-wrap items-center gap-3 mt-3">
-                      <div className="flex items-center gap-1"><TrustIcon className={"w-3.5 h-3.5 " + trustCfg.colorClass} /><span className={"text-xs font-semibold " + trustCfg.colorClass}>{trustCfg.label}</span></div>
-                      <Badge variant="outline" className={"text-xs " + tag.color}><TagIcon className="w-3 h-3 mr-1" />{tag.label}</Badge>
-                      <span className={"text-sm font-semibold " + getProbColor(prob)}>{prob}% response probability</span>
-                      {job.first_seen_at && <span className="text-xs text-muted-foreground flex items-center gap-1"><Clock className="w-3 h-3" />{Math.round((Date.now()-new Date(job.first_seen_at).getTime())/(1000*60*60*24))}d ago</span>}
-                    </div>
-                    {hasFlags && <div className="flex flex-wrap gap-1.5 mt-2">{job.flags!.map((flag, fi) => <Badge key={fi} variant="outline" className={"text-[10px] " + (flag.severity==="danger" ? "border-destructive/40 text-destructive bg-destructive/5" : "border-warning/40 text-warning bg-warning/5")}><AlertTriangle className="w-3 h-3 mr-1" />{flag.label}</Badge>)}</div>}
-                    {job.matchReason && !hasDanger && <p className="text-xs text-accent mt-2 italic">💡 {job.matchReason}</p>}
-                  </div>
-                  <div className="flex sm:flex-col gap-2 flex-shrink-0">
-                    <Button variant="outline" size="sm" className="text-xs" onClick={() => handleSaveJob(job)} disabled={!!savingJobKeys[saveKey]}>
-                      {savingJobKeys[saveKey] ? <><Loader2 className="w-3.5 h-3.5 mr-1 animate-spin" />Saving</> : <><Plus className="w-3.5 h-3.5 mr-1" />Save Job</>}
-                    </Button>
-                    <Button size="sm" className="gradient-indigo text-white text-xs" onClick={() => handleAnalyzeFit(job)}><Target className="w-3.5 h-3.5 mr-1" />Check My Chances</Button>
-                    {job.url && <Button variant="outline" size="sm" className="text-xs" onClick={() => window.open(job.url, "_blank", "noopener,noreferrer")}><ExternalLink className="w-3.5 h-3.5 mr-1" />Find & Apply</Button>}
-                    <Button variant="ghost" size="sm" className="text-xs text-muted-foreground hover:text-destructive" onClick={async () => { const ok = await ignoreJob({ title: job.title, company: job.company, url: job.url }); if (ok) { setJobs(prev => prev.filter(j => getJobSaveKey(j) !== saveKey)); setIgnoredList(prev => [...prev, { id: '', job_title: job.title, company: job.company, job_url: job.url }]); toast.success("Job hidden"); } }}>
-                      <EyeOff className="w-3.5 h-3.5 mr-1" />Ignore
-                    </Button>
-                  </div>
-                </div>
-              </Card>
+              <JobCard
+                key={job.id || i}
+                job={job}
+                isSaving={!!savingJobKeys[saveKey]}
+                onSave={() => handleSaveJob(job)}
+                onAnalyze={() => handleAnalyzeFit(job)}
+                onIgnore={() => handleIgnoreJob(job)}
+                onApply={() => handleApplyJob(job)}
+              />
             );
           })}
         </div>
-        {visibleCount < jobs.filter(j => showFlagged || !j.is_flagged).length && (
-          <div className="mt-4 text-center"><Button variant="outline" onClick={() => setVisibleCount(prev => prev + PAGE_SIZE)}>Load More ({jobs.filter(j => showFlagged || !j.is_flagged).length - visibleCount} remaining)</Button></div>
+
+        {/* Load more */}
+        {visibleCount < visibleJobs.length && (
+          <div className="mt-4 text-center">
+            <Button variant="outline" onClick={() => setVisibleCount(prev => prev + PAGE_SIZE)}>
+              Load More ({visibleJobs.length - visibleCount} remaining)
+            </Button>
+          </div>
         )}
-        {citations.length > 0 && (
-          <div className="mt-6 pt-4 border-t border-border"><p className="text-xs text-muted-foreground mb-2">Sources:</p><div className="flex flex-wrap gap-2">{citations.map((c, i) => <a key={i} href={c} target="_blank" rel="noopener noreferrer" className="text-xs text-accent hover:underline truncate max-w-xs">[{i+1}] {c}</a>)}</div></div>
-        )}
+
+        {/* Empty state */}
         {!searching && jobs.length === 0 && profileLoaded && (
           <div className="text-center py-16 text-muted-foreground">
             <Search className="w-12 h-12 mx-auto mb-4 opacity-30" />
             {skills.length > 0 || targetTitles.length > 0 ? (
-              <><p className="text-lg mb-2">No jobs matched your filters</p><p className="text-sm mb-4">Try lowering the minimum fit score, removing location, or broadening job types</p><Button variant="outline" onClick={() => handleSearch({ minFitScore: 0, showFlagged: true })}>Browse all jobs (ignore filters)</Button></>
+              <>
+                <p className="text-lg mb-2">No jobs matched your filters</p>
+                <p className="text-sm mb-4">Try lowering the minimum fit score, removing location, or broadening job types</p>
+                <Button variant="outline" onClick={() => handleSearch({ minFitScore: 0, showFlagged: true })}>Browse all jobs</Button>
+              </>
             ) : (
-              <><p className="text-lg mb-2">Set up your profile or search manually above</p><p className="text-sm mb-4">No skills or titles saved yet — add them to your <button className="text-accent hover:underline" onClick={() => navigate("/profile")}>Career Profile</button>, or click below to browse everything</p><Button variant="outline" onClick={() => handleSearch({ skills: [], targetTitles: [], minFitScore: 0 })}>Browse all →</Button></>
+              <>
+                <p className="text-lg mb-2">Set up your profile to get personalized results</p>
+                <p className="text-sm mb-4">Add skills and target titles to your <button className="text-accent hover:underline" onClick={() => navigate("/profile")}>Career Profile</button>, or browse everything below</p>
+                <Button variant="outline" onClick={() => handleSearch({ skills: [], targetTitles: [], minFitScore: 0 })}>Browse all →</Button>
+              </>
             )}
           </div>
         )}

--- a/src/services/job/service.ts
+++ b/src/services/job/service.ts
@@ -1,13 +1,19 @@
 /**
  * Job Service — Core search logic.
- * Handles job search via edge function (async polling) and direct DB queries.
- * No cross-service imports.
+ *
+ * v6: Calls discover-jobs edge function (passes userId for AI enrichment)
+ * instead of querying scraped_jobs view directly.
+ *
+ * The edge function returns AI fit scores, skill gaps, smart tags, and
+ * triggers background match-jobs when unscored jobs exist.
  */
 
 import { supabase } from "@/integrations/supabase/client";
-import type { JobResult, JobSearchFilters } from "./types";
+import type { JobResult, JobSearchFilters, DiscoverJobsResponse } from "./types";
 
-// ── URL normalization (kept from original) ─────────────────────────────
+// ---------------------------------------------------------------------------
+// URL normalization (unchanged)
+// ---------------------------------------------------------------------------
 
 export function normalizeJobUrl(rawUrl?: string | null): string {
   if (!rawUrl) return '';
@@ -23,10 +29,7 @@ export function normalizeJobUrl(rawUrl?: string | null): string {
     try {
       const urlObj = new URL(url);
       redirectParams.forEach(param => {
-        if (urlObj.searchParams.has(param)) {
-          url = urlObj.searchParams.get(param) || url;
-          urlObj.searchParams.delete(param);
-        }
+        if (urlObj.searchParams.has(param)) { url = urlObj.searchParams.get(param) || url; }
       });
     } catch { break; }
   }
@@ -40,74 +43,9 @@ export function normalizeJobUrl(rawUrl?: string | null): string {
   } catch { return ''; }
 }
 
-// ── Fresh token helper ─────────────────────────────────────────────────
-
-// NOTE: Only used by AI search (currently disabled). Keep for future re-enablement.
-async function getFreshToken(): Promise<string | null> {
-  try {
-    const { data } = await supabase.auth.refreshSession();
-    return data.session?.access_token ?? null;
-  } catch {
-    const { data } = await supabase.auth.getSession();
-    return data.session?.access_token ?? null;
-  }
-}
-
-// ── Resilient fetch with retries ───────────────────────────────────────
-
-// NOTE: Only used by AI search (currently disabled). Keep for future re-enablement.
-async function resilientFetch(
-  url: string,
-  options: RequestInit,
-  maxRetries = 2
-): Promise<Response> {
-  let lastError: Error | null = null;
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 30000);
-      const resp = await fetch(url, { ...options, signal: controller.signal });
-      clearTimeout(timeout);
-      if (resp.status === 401 && attempt < maxRetries) {
-        const newToken = await getFreshToken();
-        if (newToken) {
-          const headers = new Headers(options.headers);
-          headers.set("Authorization", `Bearer ${newToken}`);
-          options = { ...options, headers };
-        }
-        continue;
-      }
-      if (resp.status >= 500 && attempt < maxRetries) {
-        await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
-        continue;
-      }
-      return resp;
-    } catch (e: any) {
-      lastError = e;
-      if (attempt < maxRetries) await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
-    }
-  }
-  throw lastError || new Error("Fetch failed after retries");
-}
-
-// ── Edge function URL builder ──────────────────────────────────────────
-
-function getEdgeFunctionUrl(name: string): string {
-  const projectId = import.meta.env.VITE_SUPABASE_PROJECT_ID;
-  return `https://${projectId}.supabase.co/functions/v1/${name}`;
-}
-
-// ── Search Jobs (main entry — database-only mode) ────────────────────────
-
-// Main entry: database-only search — zero external cost
-export async function searchJobs(
-  filters: JobSearchFilters
-): Promise<{ jobs: JobResult[]; citations: string[] }> {
-  const dbJobs = await searchDatabaseJobs(filters);
-  return { jobs: dbJobs, citations: [] };
-}
-
-// ── Database-only search ───────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Career level → seniority map (for local fallback scoring)
+// ---------------------------------------------------------------------------
 
 const CAREER_LEVEL_TO_SENIORITY: Record<string, string[]> = {
   "Entry-Level / Junior": ["entry", "junior", "intern"],
@@ -126,9 +64,162 @@ const JOB_TYPE_MAP: Record<string, string[]> = {
   "short-term": ["temporary", "temp", "short-term"],
 };
 
-export async function searchDatabaseJobs(
+// ---------------------------------------------------------------------------
+// Main entry: searchJobs
+// Calls discover-jobs v6 edge function — returns AI-enriched results
+// ---------------------------------------------------------------------------
+
+export async function searchJobs(
   filters: JobSearchFilters
-): Promise<JobResult[]> {
+): Promise<{ jobs: JobResult[]; citations: string[]; matchingTriggered: boolean }> {
+  const { data: { session } } = await supabase.auth.getSession();
+  const userId = session?.user?.id ?? null;
+
+  try {
+    // Build search term from titles + skills + query
+    const searchTermParts = [
+      ...filters.targetTitles,
+      ...(filters.query ? [filters.query] : []),
+      // Include top 3 skills as keyword search
+      ...filters.skills.slice(0, 3),
+    ].filter(Boolean);
+
+    const searchTerm = searchTermParts.join(" ") || "software engineer";
+
+    const payload: Record<string, unknown> = {
+      searchTerm,
+      userId,
+      location: filters.location || undefined,
+      isRemote: filters.jobTypes.includes("remote") || undefined,
+      jobType: buildJobTypeFilter(filters.jobTypes),
+      minFitScore: filters.minFitScore > 0 ? filters.minFitScore : undefined,
+      hoursOld: filters.days_old ? filters.days_old * 24 : 48,
+      limit: filters.search_mode === "volume" ? 200 : 100,
+      offset: filters.offset ?? 0,
+      triggerMatch: !!userId,
+    };
+
+    const { data, error } = await supabase.functions.invoke<DiscoverJobsResponse>("discover-jobs", {
+      body: payload,
+    });
+
+    if (error || !data) {
+      console.warn("[searchJobs] Edge function failed, falling back to DB:", error?.message);
+      const dbJobs = await searchDatabaseJobsFallback(filters);
+      return { jobs: dbJobs, citations: [], matchingTriggered: false };
+    }
+
+    const jobs: JobResult[] = (data.jobs ?? []).map((row: any) => ({
+      id: row.id,
+      title: row.title || "Job Opportunity",
+      company: row.company || "Company",
+      location: row.location || "Remote",
+      type: row.job_type || "full-time",
+      description: row.description || "",
+      url: normalizeJobUrl(row.job_url) || normalizeJobUrl(row.apply_url) || "",
+      matchReason: row.match_summary || "Database match",
+      quality_score: row.quality_score ?? 50,
+      is_flagged: row.is_flagged ?? false,
+      flag_reasons: row.flag_reasons ?? [],
+      salary: formatSalary(row.salary_min, row.salary_max, row.salary_currency),
+      seniority: row.seniority,
+      is_remote: row.is_remote,
+      source: row.source || "database",
+      first_seen_at: row.scraped_at || row.date_posted,
+      // AI match fields
+      fit_score: row.fit_score ?? null,
+      matched_skills: row.matched_skills ?? [],
+      skill_gaps: row.skill_gaps ?? [],
+      strengths: row.strengths ?? [],
+      red_flags: row.red_flags ?? [],
+      match_summary: row.match_summary ?? "",
+      effort_level: row.effort_level,
+      response_prob: row.response_prob ?? null,
+      smart_tag: row.smart_tag ?? null,
+      is_saved: row.is_saved ?? false,
+      is_applied: row.is_applied ?? false,
+    }));
+
+    return { jobs, citations: [], matchingTriggered: data.matchingTriggered ?? false };
+
+  } catch (e) {
+    console.error("[searchJobs] Exception:", e);
+    const dbJobs = await searchDatabaseJobsFallback(filters);
+    return { jobs: dbJobs, citations: [], matchingTriggered: false };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Poll for updated AI scores after matchingTriggered
+// Call this ~5s after search when matchingTriggered=true to get scores
+// ---------------------------------------------------------------------------
+
+export async function pollMatchScores(jobIds: string[]): Promise<Map<string, Partial<JobResult>>> {
+  if (!jobIds.length) return new Map();
+
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return new Map();
+
+  const { data, error } = await supabase
+    .from("user_job_matches")
+    .select("job_id, fit_score, matched_skills, skill_gaps, strengths, red_flags, match_summary, effort_level, response_prob, smart_tag")
+    .eq("user_id", session.user.id)
+    .in("job_id", jobIds);
+
+  if (error || !data) return new Map();
+
+  return new Map(data.map((m: any) => [m.job_id, {
+    fit_score: m.fit_score,
+    matched_skills: m.matched_skills ?? [],
+    skill_gaps: m.skill_gaps ?? [],
+    strengths: m.strengths ?? [],
+    red_flags: m.red_flags ?? [],
+    match_summary: m.match_summary ?? "",
+    effort_level: m.effort_level,
+    response_prob: m.response_prob,
+    smart_tag: m.smart_tag,
+  }]));
+}
+
+// ---------------------------------------------------------------------------
+// Mark job interaction (seen / saved / ignored / applied)
+// ---------------------------------------------------------------------------
+
+export async function markJobInteraction(jobId: string, action: "seen" | "saved" | "ignored" | "applied"): Promise<void> {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return;
+  await supabase.rpc("mark_job_interaction", {
+    p_user_id: session.user.id,
+    p_job_id: jobId,
+    p_action: action,
+  }).catch(() => {}); // non-fatal
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildJobTypeFilter(jobTypes: string[]): string | undefined {
+  const structural = jobTypes.filter(t => !["remote", "hybrid", "in-office"].includes(t));
+  if (!structural.length) return undefined;
+  // Map to DB job_type values
+  const mapped = structural.flatMap(t => JOB_TYPE_MAP[t] ?? [t]);
+  return mapped[0]; // discover-jobs only accepts single value; primary type
+}
+
+function formatSalary(min: number | null, max: number | null, currency = "USD"): string | undefined {
+  if (!min && !max) return undefined;
+  const fmt = (n: number) => "$" + Math.round(n).toLocaleString();
+  if (min && max) return `${fmt(min)} – ${fmt(max)}`;
+  if (min) return `${fmt(min)}+`;
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Fallback: direct DB query (used when edge function fails)
+// ---------------------------------------------------------------------------
+
+export async function searchDatabaseJobsFallback(filters: JobSearchFilters): Promise<JobResult[]> {
   try {
     const limit  = filters.search_mode === "volume" ? 800 : 200;
     const offset = filters.offset ?? 0;
@@ -139,7 +230,6 @@ export async function searchDatabaseJobs(
       .order("quality_score", { ascending: false })
       .range(offset, offset + limit - 1);
 
-    // ── Text search ────────────────────────────────────────────────────
     const orParts: string[] = [];
     for (const t of filters.targetTitles) {
       const escaped = t.replace(/%/g, "\\%").replace(/_/g, "\\_");
@@ -155,81 +245,47 @@ export async function searchDatabaseJobs(
       if (kw.length >= 4) orParts.push(`description.ilike.%${kw}%`);
     }
     if (orParts.length > 0) query = query.or(orParts.join(","));
-
-    // ── Location filter ────────────────────────────────────────────────
-    if (filters.location && !/^\s*remote\s*$/i.test(filters.location)) {
-      query = query.ilike("location", `%${filters.location}%`);
-    }
-
-    // ── Remote filter ──────────────────────────────────────────────────
+    if (filters.location && !/^\s*remote\s*$/i.test(filters.location)) query = query.ilike("location", `%${filters.location}%`);
     if (filters.jobTypes.includes("remote")) query = query.eq("is_remote", true);
-
-    // ── Structured job type filter ─────────────────────────────────────
-    const structuredTypes = filters.jobTypes
-      .filter(t => !["remote", "hybrid", "in-office"].includes(t))
-      .flatMap(t => JOB_TYPE_MAP[t] ?? [t]);
-    if (structuredTypes.length > 0) {
-      query = query.or(structuredTypes.map(t => `job_type.ilike.%${t}%`).join(","));
-    }
-
-    // ── Seniority / career level filter ───────────────────────────────
+    const structuredTypes = filters.jobTypes.filter(t => !["remote","hybrid","in-office"].includes(t)).flatMap(t => JOB_TYPE_MAP[t] ?? [t]);
+    if (structuredTypes.length > 0) query = query.or(structuredTypes.map(t => `job_type.ilike.%${t}%`).join(","));
     if (filters.careerLevel) {
       const levels = filters.careerLevel.split(",").map(s => s.trim()).filter(Boolean);
       const seniorityValues = levels.flatMap(l => CAREER_LEVEL_TO_SENIORITY[l] ?? []);
-      if (seniorityValues.length > 0) {
-        query = query.or(seniorityValues.map(s => `seniority.ilike.%${s}%`).join(","));
-      }
+      if (seniorityValues.length > 0) query = query.or(seniorityValues.map(s => `seniority.ilike.%${s}%`).join(","));
     }
-
-    // ── Salary filter (uses market_rate numeric column) ────────────────
     const salaryMinNum = filters.salaryMin ? parseInt(filters.salaryMin.replace(/\D/g, ""), 10) : null;
     const salaryMaxNum = filters.salaryMax ? parseInt(filters.salaryMax.replace(/\D/g, ""), 10) : null;
     if (salaryMinNum && !isNaN(salaryMinNum)) query = query.gte("market_rate", salaryMinNum);
     if (salaryMaxNum && !isNaN(salaryMaxNum)) query = query.lte("market_rate", salaryMaxNum);
-
-    // ── Freshness filter ───────────────────────────────────────────────
     const daysOld = filters.days_old ?? 0;
     if (daysOld > 0) {
       const cutoff = new Date(Date.now() - daysOld * 24 * 60 * 60 * 1000).toISOString();
       query = query.gte("first_seen_at", cutoff);
     }
-
-    // ── Flagged filter ─────────────────────────────────────────────────
     if (!filters.showFlagged) query = query.eq("is_flagged", false);
 
     const { data, error } = await query;
-    if (error) { console.error("[searchDatabaseJobs] Error:", error.message); return []; }
+    if (error) { console.error("[searchDatabaseJobsFallback] Error:", error.message); return []; }
 
     return (data || []).map((row: any) => ({
-      id: row.id,
-      title: row.title || "Job Opportunity",
-      company: row.company || "Company",
-      location: row.location || "Remote",
-      type: row.job_type || "full-time",
-      description: row.description || "",
-      url: normalizeJobUrl(row.job_url) || "",
-      matchReason: "Database match",
-      quality_score: row.quality_score ?? 50,
-      is_flagged: row.is_flagged ?? false,
-      flag_reasons: row.flag_reasons ?? [],
-      salary: row.salary,
-      seniority: row.seniority,
-      is_remote: row.is_remote,
-      source: row.source || "database",
-      first_seen_at: row.first_seen_at,
+      id: row.id, title: row.title || "Job Opportunity", company: row.company || "Company",
+      location: row.location || "Remote", type: row.job_type || "full-time",
+      description: row.description || "", url: normalizeJobUrl(row.job_url) || "",
+      matchReason: "Database match", quality_score: row.quality_score ?? 50,
+      is_flagged: row.is_flagged ?? false, flag_reasons: row.flag_reasons ?? [],
+      salary: row.salary, seniority: row.seniority, is_remote: row.is_remote,
+      source: row.source || "database", first_seen_at: row.first_seen_at,
     }));
   } catch (e) {
-    console.error("[searchDatabaseJobs] Exception:", e);
+    console.error("[searchDatabaseJobsFallback] Exception:", e);
     return [];
   }
 }
 
-// ── AI search (disabled in database-only mode) ─────────────────────────
+// Keep backward-compat export
+export { searchJobs as searchDatabaseJobs };
 
-// AI search via edge function — DISABLED (database-only mode, zero cost)
-export async function searchAIJobs(
-  filters: JobSearchFilters
-): Promise<{ jobs: JobResult[]; citations: string[] }> {
-  console.info("[searchAIJobs] Skipped — database-only mode active. AI search disabled to operate at zero cost.");
+export async function searchAIJobs(): Promise<{ jobs: JobResult[]; citations: string[] }> {
   return { jobs: [], citations: [] };
 }

--- a/src/services/job/types.ts
+++ b/src/services/job/types.ts
@@ -21,6 +21,21 @@ export interface JobResult {
   is_remote?: boolean;
   source?: string;
   first_seen_at?: string;
+
+  // AI match fields (from user_job_matches via discover-jobs v6)
+  fit_score?: number | null;
+  matched_skills?: string[];
+  skill_gaps?: string[];
+  strengths?: string[];
+  red_flags?: string[];
+  match_summary?: string;
+  effort_level?: "easy" | "moderate" | "hard";
+  response_prob?: number | null;
+  smart_tag?: string;
+  is_saved?: boolean;
+  is_applied?: boolean;
+
+  // Local scoring fields (computed client-side when AI scores unavailable)
   responseProbability?: number;
   smartTag?: string;
   decisionScore?: number;
@@ -44,9 +59,7 @@ export interface JobSearchFilters {
   minFitScore: number;
   showFlagged: boolean;
   search_mode?: "quality" | "balanced" | "volume";
-  /** Only return jobs posted within the last N days (0 = no limit) */
   days_old?: number;
-  /** Pagination offset for DB-level cursor paging */
   offset?: number;
 }
 
@@ -55,4 +68,13 @@ export interface ParsedJobDescription {
   benefitsText: string;
   companyText: string;
   fullText: string;
+}
+
+// discover-jobs v6 response
+export interface DiscoverJobsResponse {
+  jobs: JobResult[];
+  total: number;
+  searchTerm: string;
+  matchingTriggered: boolean;
+  source: string;
 }


### PR DESCRIPTION
## What

Completes the job search agent: wires the AI match scores from `discover-jobs v6` into the frontend, adds background score polling, and sets up the cron to keep jobs fresh.

## UI changes (`JobSearch.tsx`)

- **AI Fit Score badge** — prominent colored badge per job (green ≥80%, amber ≥60%, red <60%)
- **Skill breakdown** — expandable per-job panel showing matched skills (green) + skill gaps (amber) + AI match summary
- **Smart tag** — uses AI `smart_tag` (hot_match, good_fit, stretch, reach, apply_fast, low_roi) when available, falls back to local scoring
- **Matching banner** — shows "Analyzing your fit score…" while background matching runs; clears when complete
- **Live polling** — `pollMatchScores()` polls every 5s for incoming AI scores, merges into results, re-ranks by fit
- **Default sort: AI Fit Score** instead of Decision Score
- **Job interactions** — `markJobInteraction()` records seen/saved/ignored/applied

## Service changes

- `searchJobs()` calls `discover-jobs v6` edge function (passes `userId`)
- Falls back to direct DB query if edge function fails
- `pollMatchScores()` reads `user_job_matches` for specific job IDs
- `markJobInteraction()` calls `mark_job_interaction` RPC
- `DiscoverJobsResponse` type + AI match fields added to `JobResult`

## GitHub Actions

- `job-feeds.yml` — cron every 2h, triggers `job-feeds` edge function
- `migrate-job-search-agent.yml` — manual trigger to apply 3 DB migrations