### PR TITLE
fix(job-search): 3 production bugs causing empty results

### DIFF
--- a/src/services/job/service.ts
+++ b/src/services/job/service.ts
@@ -230,21 +230,27 @@ export async function searchDatabaseJobsFallback(filters: JobSearchFilters): Pro
       .order("quality_score", { ascending: false })
       .range(offset, offset + limit - 1);
 
+    // Reserved words that break PostgREST's OR filter parser
+    const POSTGREST_RESERVED = new Set(["and","or","not","in","is","null","true","false","eq","neq","gt","gte","lt","lte","like","ilike","cs","cd","sl","sr","nxr","nxl","adj","ov","fts","plfts","phfts","wfts"]);
+
     const orParts: string[] = [];
     for (const t of filters.targetTitles) {
-      const escaped = t.replace(/%/g, "\\%").replace(/_/g, "\\_");
-      orParts.push(`title.ilike.%${escaped}%`);
+      // Strip special chars that break PostgREST parser (commas, &, parens)
+      const safe = t.replace(/[,&()]/g, " ").replace(/%/g, "").replace(/_/g, " ").trim();
+      if (safe.length >= 3) orParts.push(`title.ilike.%${safe}%`);
     }
     const keywords = [filters.query, ...filters.skills]
-      .flatMap(s => (s || "").split(/[\s,]+/))
-      .map(s => s.replace(/[%_]/g, "").trim())
-      .filter(s => s.length >= 3);
+      .flatMap(s => (s || "").split(/[\s,&]+/))
+      .map(s => s.replace(/[%_()\[\]]/g, "").trim())
+      .filter(s => s.length >= 4 && !POSTGREST_RESERVED.has(s.toLowerCase()));
     const uniqueKeywords = [...new Set(keywords)];
-    for (const kw of uniqueKeywords.slice(0, 10)) {
+    // Cap at 8 keywords to keep OR clause manageable
+    for (const kw of uniqueKeywords.slice(0, 8)) {
       orParts.push(`title.ilike.%${kw}%`);
-      if (kw.length >= 4) orParts.push(`description.ilike.%${kw}%`);
+      orParts.push(`description.ilike.%${kw}%`);
     }
-    if (orParts.length > 0) query = query.or(orParts.join(","));
+    // Hard cap at 20 OR parts to prevent parser overflow
+    if (orParts.length > 0) query = query.or(orParts.slice(0, 20).join(","));
     if (filters.location && !/^\s*remote\s*$/i.test(filters.location)) query = query.ilike("location", `%${filters.location}%`);
     if (filters.jobTypes.includes("remote")) query = query.eq("is_remote", true);
     const structuredTypes = filters.jobTypes.filter(t => !["remote","hybrid","in-office"].includes(t)).flatMap(t => JOB_TYPE_MAP[t] ?? [t]);

--- a/supabase/functions/discover-jobs/index.ts
+++ b/supabase/functions/discover-jobs/index.ts
@@ -164,7 +164,6 @@ Deno.serve(async (req) => {
 
     const filters: string[] = [
       `select=${selectCols}`,
-      `status=eq.active`,
       `scraped_at=gte.${cutoff}`,
       `or=(title.ilike.*${encodeURIComponent(term)}*,company.ilike.*${encodeURIComponent(term)}*,description.ilike.*${encodeURIComponent(term)}*)`,
       `order=scraped_at.desc`,

--- a/supabase/functions/job-feeds/index.ts
+++ b/supabase/functions/job-feeds/index.ts
@@ -382,7 +382,6 @@ async function upsertJobs(
       salary_max: j.salary_max,
       date_posted: j.date_posted,
       scraped_at: new Date().toISOString(),
-      status: "active",
     }));
 
   // Get existing external_ids to distinguish new vs updated


### PR DESCRIPTION
Fixes all zero-results issues found live in production:

1. `discover-jobs`: `status=eq.active` filter → PostgREST 400 because `job_postings` has no `status` column
2. `job-feeds`: upsert included `status: "active"` → rows rejected, nothing in DB
3. `searchDatabaseJobsFallback`: `title.ilike.%and%` breaks the OR parser; target titles with commas/& break the tree