### PR TITLE
fix(wiring): invoke edge functions from action buttons (#207, #208)

### DIFF
--- a/src/pages/AutoApply.tsx
+++ b/src/pages/AutoApply.tsx
@@ -32,6 +32,7 @@ interface AutoApplyPrefs {
 
 interface QueuedApplication {
   id: string;
+  jobDbId?: string;        // DB id from public.jobs — used for job_queue writes
   jobTitle: string;
   company: string;
   location: string;
@@ -71,6 +72,7 @@ export default function AutoApplyPage() {
   const [locationInput, setLocationInput] = useState("");
   const [queue, setQueue] = useState<QueuedApplication[]>([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [generatingId, setGeneratingId] = useState<string | null>(null);
   const [analyzingId, setAnalyzingId] = useState<string | null>(null);
@@ -202,6 +204,7 @@ export default function AutoApplyPage() {
       return;
     }
     setIsSearching(true);
+    setSearchError(null);
     try {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) { toast.error("Please sign in"); return; }
@@ -212,27 +215,22 @@ export default function AutoApplyPage() {
         .eq("user_id", session.user.id)
         .maybeSingle();
 
-      const resp = await fetch(
-        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/search-jobs`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${session.access_token}`,
-          },
-          body: JSON.stringify({
-            skills: (profile?.skills as string[]) || [],
-            jobTypes: (profile as any)?.preferred_job_types || [],
-            location: prefs.locations.join(", ") || (profile?.location as string) || "",
-            careerLevel: (profile as any)?.career_level || "",
-            targetTitles: prefs.jobTitles,
-            query: prefs.remoteOnly ? "remote positions only" : "",
-          }),
-        }
-      );
+      // Invoke discover-jobs edge function via SDK (auth injected automatically)
+      const { data, error: fnErr } = await supabase.functions.invoke("discover-jobs", {
+        body: {
+          targetTitles: prefs.jobTitles,
+          skills: (profile?.skills as string[]) || [],
+          jobType: ((profile as any)?.preferred_job_types as string[])?.join(",") || undefined,
+          location: prefs.locations.join(", ") || (profile?.location as string) || undefined,
+          careerLevel: (profile as any)?.career_level || undefined,
+          isRemote: prefs.remoteOnly || undefined,
+          userId: session.user.id,
+          triggerMatch: true,
+          limit: 50,
+        },
+      });
 
-      if (!resp.ok) throw new Error("Search failed");
-      const data = await resp.json();
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Search returned no data");
       const jobs = (data.jobs || []) as any[];
 
       const resumeLookup = await getBestResumeText(session.user.id);
@@ -240,16 +238,18 @@ export default function AutoApplyPage() {
 
       const newQueue: QueuedApplication[] = jobs
         .map((job: any) => {
-          const jobDesc = `${job.title} at ${job.company}\nLocation: ${job.location}\nType: ${job.type || ""}\n\n${job.description}`;
+          const jobDesc = `${job.title} at ${job.company}\nLocation: ${job.location}\nType: ${job.job_type || job.type || ""}\n\n${job.description}`;
           const analysis = resumeText ? analyzeJobFit(jobDesc, resumeText) : null;
-          const score = analysis?.overallScore || 50;
+          // Prefer server-side fit_score; fall back to local analysis score
+          const score = job.fit_score ?? analysis?.overallScore ?? job.quality_score ?? 50;
           return {
             id: crypto.randomUUID(),
+            jobDbId: job.id || undefined,
             jobTitle: job.title,
             company: job.company,
             location: job.location,
-            matchScore: score,
-            status: score >= prefs.minMatchScore ? "review" as const : "skipped" as const,
+            matchScore: Math.round(score),
+            status: Math.round(score) >= prefs.minMatchScore ? "review" as const : "skipped" as const,
             jobDescription: jobDesc,
             analysis,
           };
@@ -258,7 +258,22 @@ export default function AutoApplyPage() {
 
       setQueue((prev) => [...newQueue, ...prev]);
       addLog("Search complete", `Found ${newQueue.filter(j => j.status === "review").length} matching jobs`, "search");
-      
+
+      // Persist review-eligible jobs to job_queue so Supabase tracks them
+      const reviewJobs = newQueue.filter(j => j.status === "review" && j.jobDbId);
+      if (reviewJobs.length > 0) {
+        const { error: qErr } = await supabase.from("job_queue").insert(
+          reviewJobs.map(j => ({
+            job_id: j.jobDbId!,
+            user_id: session.user.id,
+            type: "auto_apply",
+            status: "pending",
+            payload: { matchScore: j.matchScore, jobTitle: j.jobTitle, company: j.company },
+          }))
+        );
+        if (qErr) logger.warn("[AutoApply] job_queue insert partial error:", qErr.message);
+      }
+
       // Smart/Auto mode: auto-approve high matches
       if (prefs.applyMode === "smart" || prefs.applyMode === "full-auto") {
         const threshold = prefs.applyMode === "full-auto" ? prefs.minMatchScore : 80;
@@ -268,14 +283,20 @@ export default function AutoApplyPage() {
           }
         }
       }
-      
-      if (resumeLookup.source === "profile") {
-        toast.success(`Found ${newQueue.filter(j => j.status === "review").length} jobs. Using your profile for fit analysis.`);
+
+      const reviewCount = newQueue.filter(j => j.status === "review").length;
+      if (reviewCount === 0) {
+        toast.info(`No jobs met your ${prefs.minMatchScore}% threshold. Try lowering it or broadening your titles.`);
+      } else if (resumeLookup.source === "profile") {
+        toast.success(`Found ${reviewCount} jobs. Using your profile for fit analysis.`);
       } else {
-        toast.success(`Found ${newQueue.filter(j => j.status === "review").length} jobs above ${prefs.minMatchScore}% threshold`);
+        toast.success(`Found ${reviewCount} jobs above ${prefs.minMatchScore}% threshold`);
       }
-    } catch {
-      toast.error("Auto-search failed");
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Auto-search failed";
+      setSearchError(msg);
+      toast.error("Queue failed. Please retry.");
+      logger.error("[AutoApply] runAutoSearch error:", e);
     } finally {
       setIsSearching(false);
     }
@@ -639,6 +660,23 @@ export default function AutoApplyPage() {
             )}
           </div>
         </Card>
+
+        {/* Search error state */}
+        {searchError && !isSearching && (
+          <div className="text-center py-8 text-destructive">
+            <p className="font-medium mb-1">Queue failed. Please retry.</p>
+            <p className="text-sm text-muted-foreground">{searchError}</p>
+          </div>
+        )}
+
+        {/* Zero-matches state */}
+        {!isSearching && !searchError && queue.length === 0 && profileLoaded && (
+          <div className="text-center py-8 text-muted-foreground">
+            <Search className="w-10 h-10 mx-auto mb-3 opacity-30" />
+            <p className="font-medium">No matching jobs found</p>
+            <p className="text-sm mt-1">Try adding more job titles or lowering your minimum match score.</p>
+          </div>
+        )}
 
         {/* Application Queue */}
         {queue.length > 0 && (

--- a/src/pages/Career.tsx
+++ b/src/pages/Career.tsx
@@ -34,6 +34,7 @@ export default function CareerPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [analyzing, setAnalyzing] = useState(false);
+  const [careerError, setCareerError] = useState<string | null>(null);
   const [insight, setInsight] = useState<CareerInsight | null>(null);
   const [editingGoals, setEditingGoals] = useState(false);
 
@@ -100,6 +101,7 @@ export default function CareerPage() {
 
   const analyzeCareer = async () => {
     setAnalyzing(true);
+    setCareerError(null);
     try {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) { toast.error("Please sign in"); return; }
@@ -112,10 +114,9 @@ export default function CareerPage() {
 
       const { data: history } = await supabase.from("analysis_history" as any).select("job_title, overall_score, gaps, matched_skills").eq("user_id", session.user.id).order("created_at", { ascending: false }).limit(5) as any;
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/career-path-analysis`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({
+      // Invoke career-path-analysis via SDK (replaces raw fetch — auth injected automatically)
+      const { data, error: fnErr } = await supabase.functions.invoke("career-path-analysis", {
+        body: {
           skills: profile.skills,
           careerLevel: (profile as any).career_level,
           experience: profile.work_experience,
@@ -124,12 +125,19 @@ export default function CareerPage() {
           targetTitles: (profile as any).target_job_titles,
           recentAnalyses: history || [],
           includeRoadmap: true,
-        }),
+        },
       });
-      if (!resp.ok) throw new Error("Analysis failed");
-      setInsight(await resp.json());
-    } catch { toast.error("Failed to analyze career path"); }
-    finally { setAnalyzing(false); }
+
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Roadmap generation failed");
+      setInsight(data as CareerInsight);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Roadmap failed";
+      setCareerError(msg);
+      toast.error("Roadmap failed. Please retry.");
+      logger.error("[Career] analyzeCareer error:", e);
+    } finally {
+      setAnalyzing(false);
+    }
   };
 
   if (loading) return <div className="min-h-screen bg-background flex items-center justify-center"><Loader2 className="w-8 h-8 animate-spin text-accent" /></div>;
@@ -226,12 +234,19 @@ export default function CareerPage() {
             </Button>
           </div>
 
-          {!insight ? (
+          {careerError && !analyzing && (
+            <div className="text-center py-8 text-destructive">
+              <p className="font-medium mb-1">Roadmap failed. Please retry.</p>
+              <p className="text-sm text-muted-foreground">{careerError}</p>
+            </div>
+          )}
+
+          {!insight && !careerError ? (
             <div className="text-center py-8">
               <Map className="w-12 h-12 text-muted-foreground mx-auto mb-3" />
-              <p className="text-muted-foreground">Generate your personalized career roadmap based on your profile, skills, and market data.</p>
+              <p className="text-muted-foreground">{analyzing ? "Generating roadmap…" : "Generate your personalized career roadmap based on your profile, skills, and market data."}</p>
             </div>
-          ) : (
+          ) : insight ? (
             <div className="space-y-6">
               {/* Current Level */}
               <div className="flex items-center gap-3 p-3 rounded-lg bg-accent/5 border border-accent/20">
@@ -308,7 +323,7 @@ export default function CareerPage() {
                 <p className="text-sm text-foreground leading-relaxed">{insight.advice}</p>
               </Card>
             </div>
-          )}
+          ) : null}
         </Card>
 
         {/* Salary Projections */}

--- a/src/pages/JobSearch.tsx
+++ b/src/pages/JobSearch.tsx
@@ -294,6 +294,8 @@ export default function JobSearchPage() {
   // Results
   const [jobs, setJobs] = useState<EnrichedJob[]>([]);
   const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [searchRan, setSearchRan] = useState(false); // true once any search has completed
   const [matchingInProgress, setMatchingInProgress] = useState(false);
   const [totalBeforeFilter, setTotalBeforeFilter] = useState(0);
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
@@ -364,6 +366,7 @@ export default function JobSearchPage() {
   const handleSearch = async (overrideFilters?: Partial<JobSearchFilters>) => {
     if (pollTimerRef.current) { clearTimeout(pollTimerRef.current); pollTimerRef.current = null; }
     setSearching(true);
+    setSearchError(null);
     setJobs([]);
     setMatchingInProgress(false);
 
@@ -388,7 +391,9 @@ export default function JobSearchPage() {
       triggeredMatch = result.matchingTriggered;
     } catch (e) {
       logger.error("[JobSearch] error:", e);
-      toast.error("Search encountered an issue.");
+      const msg = e instanceof Error ? e.message : "Search encountered an issue.";
+      setSearchError(msg);
+      toast.error("Search failed. Please retry.");
     }
 
     // Filter out ignored / already-saved
@@ -423,6 +428,7 @@ export default function JobSearchPage() {
       toast.info("No jobs found. Try adjusting your criteria.");
     }
 
+    setSearchRan(true);
     setSearching(false);
 
     // Schedule poll for AI scores if match was triggered
@@ -640,7 +646,7 @@ export default function JobSearchPage() {
             </div>
 
             <Button className="gradient-indigo text-white shadow-indigo-500/20 hover:opacity-90 w-full sm:w-auto" disabled={searching} onClick={() => handleSearch()}>
-              {searching ? <><Loader2 className="w-4 h-4 animate-spin mr-2" />Searching...</> : <><Search className="w-4 h-4 mr-2" />Search Jobs</>}
+              {searching ? <><Loader2 className="w-4 h-4 animate-spin mr-2" />Scanning live jobs…</> : <><Search className="w-4 h-4 mr-2" />Search Jobs</>}
             </Button>
           </div>
         </Card>
@@ -720,15 +726,26 @@ export default function JobSearchPage() {
           </div>
         )}
 
-        {/* Empty state */}
-        {!searching && jobs.length === 0 && profileLoaded && (
+        {/* Empty states — four distinct cases */}
+
+        {/* api-error: search threw */}
+        {!searching && searchError && (
+          <div className="text-center py-16 text-destructive">
+            <Search className="w-12 h-12 mx-auto mb-4 opacity-40" />
+            <p className="text-lg mb-2">Search failed. Please retry.</p>
+            <p className="text-sm text-muted-foreground mb-4">{searchError}</p>
+            <Button variant="outline" onClick={() => handleSearch()}>Retry</Button>
+          </div>
+        )}
+
+        {/* idle: no search run yet */}
+        {!searching && !searchError && !searchRan && profileLoaded && (
           <div className="text-center py-16 text-muted-foreground">
             <Search className="w-12 h-12 mx-auto mb-4 opacity-30" />
             {skills.length > 0 || targetTitles.length > 0 ? (
               <>
-                <p className="text-lg mb-2">No jobs matched your filters</p>
-                <p className="text-sm mb-4">Try lowering the minimum fit score, removing location, or broadening job types</p>
-                <Button variant="outline" onClick={() => handleSearch({ minFitScore: 0, showFlagged: true, careerLevel: "" })}>Browse all jobs</Button>
+                <p className="text-lg mb-2">Ready to scan</p>
+                <p className="text-sm mb-4">Click Search Jobs to find live matches for your profile.</p>
               </>
             ) : (
               <>
@@ -737,6 +754,16 @@ export default function JobSearchPage() {
                 <Button variant="outline" onClick={() => handleSearch({ skills: [], targetTitles: [], minFitScore: 0, careerLevel: "" })}>Browse all →</Button>
               </>
             )}
+          </div>
+        )}
+
+        {/* zero-matches: search completed, no results */}
+        {!searching && !searchError && searchRan && jobs.length === 0 && (
+          <div className="text-center py-16 text-muted-foreground">
+            <Search className="w-12 h-12 mx-auto mb-4 opacity-30" />
+            <p className="text-lg mb-2">No jobs matched your filters</p>
+            <p className="text-sm mb-4">Try broadening your criteria — lower the fit score, remove the location filter, or add more job titles.</p>
+            <Button variant="outline" onClick={() => handleSearch({ minFitScore: 0, showFlagged: true, careerLevel: "" })}>Browse all jobs</Button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Fixes #207. Fixes #208.

Wires three action buttons to their configured Supabase edge functions and adds distinct UI states to replace the single silent empty-state.

### What changed

| Page | Button | Before | After |
|---|---|---|---|
| Opportunity Radar | Search Jobs | `discover-jobs` via orchestrator ✓ correct; added `searchError`/`searchRan` + 4-state empty UI | same invoke, better error/empty handling |
| Autopilot Mode | Find & Queue Jobs | raw `fetch(search-jobs)` — disabled fn, no job_queue write | `supabase.functions.invoke("discover-jobs")` + batch-insert to `public.job_queue` |
| Flight Plan | Generate Roadmap | raw `fetch(career-path-analysis)` — bypassed SDK auth | `supabase.functions.invoke("career-path-analysis")` |

### UI states added

**Opportunity Radar:** idle / searching ("Scanning live jobs…") / api-error (inline retry) / zero-matches ("No jobs matched your filters. Try broadening.")

**Autopilot Mode:** searching / api-error ("Queue failed. Retry.") / zero-matches ("No matching jobs found")

**Flight Plan:** analyzing ("Generating roadmap…") / api-error ("Roadmap failed. Retry.")

### Why discovery-agent was not used for Autopilot

`discovery-agent` requires a service-role JWT and is a scheduled board-scraper — not callable from a browser session. The correct user-facing function is `discover-jobs`, which accepts per-user filter params.

### TypeScript: zero errors

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)