### PR TITLE
chore: retire stale Supabase ref gberhsbddthwkjimsqig

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# iCareerOS — Claude Workspace Instructions
+
+> These rules apply to all Claude sessions working in this repo.
+
+## Supabase Project Refs
+
+| Environment | Ref | Name |
+|---|---|---|
+| **Production** | `bryoehuhhhjqcueomgev` | CareerPlatform |
+| **Staging** | `muevgfmpzykihjuihnga` | icareeros-staging (created 2026-04-19) |
+
+⚠️ The ref `gberhsbddthwkjimsqig` (old Lovable project) **no longer exists** in the org. Do not reference it anywhere.
+
+## Branch Policy
+
+- All work targets `dev`. Feature branches from `dev`, PR back to `dev`.
+- **Never push to `main`** — main is protected and deployment-gated.
+- Delete feature branches after merge.
+
+## Stack Quick Reference
+
+| Component | Technology |
+|---|---|
+| Framework | React 18 + TypeScript 5.8 |
+| Build | Vite + Bun |
+| Styling | Tailwind CSS + shadcn/ui |
+| Backend | Supabase (PostgreSQL, Edge Functions, Auth) |
+| Hosting | Vercel (jabri-solutions team) |
+| Payments | Stripe + Stripe Connect |
+| AI | Anthropic Claude |
+| Email | Resend |
+
+## Edge Function Invocation
+
+Always use `supabase.functions.invoke("<fn>", { body })` — never raw `fetch(VITE_SUPABASE_URL/functions/v1/...)`.
+
+Exception: SSE streaming responses (e.g. `mock-interview`) require raw fetch with `resp.body?.getReader()`.
+
+## Active Edge Functions (verified 2026-04-20)
+
+`discover-jobs`, `career-path-analysis`, `match-jobs`, `discovery-agent`, `search-jobs`
+
+## Never
+
+- Commit secrets or `.env` values
+- Modify production schema without explicit approval
+- Touch DNS or registrar settings

--- a/docs/iCareerOS-Consolidated-Build-Plan.md
+++ b/docs/iCareerOS-Consolidated-Build-Plan.md
@@ -73,7 +73,7 @@ The following decisions resolve all conflicts between the original 11-phase prod
 
 9. **Missing canonical entries:** Skill Store, Skill Radar, Network Tracker, and Career XP are now added to the canonical table above. They are future modules built in Phase 8+ alongside the Crew automation.
 
-10. **Supabase project ref:** Production is bryoehuhhhjqcueomgev (CareerPlatform). The old Lovable ref gberhsbddthwkjimsqig is deprecated and must not be used for any new deployments.
+10. **Supabase project ref:** Production is `bryoehuhhhjqcueomgev` (CareerPlatform). Staging is `muevgfmpzykihjuihnga` (icareeros-staging, created 2026-04-19). The old Lovable ref `gberhsbddthwkjimsqig` no longer exists in the org and must not be referenced anywhere.
 
 ---
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,4 +1,4 @@
-project_id = "gberhsbddthwkjimsqig"
+project_id = "bryoehuhhhjqcueomgev"
 
 [functions.rewrite-resume]
 verify_jwt = false


### PR DESCRIPTION
## Summary

Closes out Task 6 from cowork-fix-wiring-gap-v3.

Retires the dead Lovable project ref (`gberhsbddthwkjimsqig`) that no longer exists in the Supabase org and was still referenced in two places.

### Changes

**`supabase/config.toml`** — `project_id` updated from stale ref to production ref `bryoehuhhhjqcueomgev`.

**`docs/iCareerOS-Consolidated-Build-Plan.md`** — Adds staging ref `muevgfmpzykihjuihnga` (icareeros-staging, created 2026-04-19) and tightens the deprecation notice.

**`CLAUDE.md`** *(new file)* — Canonical Claude workspace instructions for the repo:
- Production/staging ref table
- Branch policy (dev-only, never main)
- Stack quick reference
- `supabase.functions.invoke()` rule with SSE streaming exception documented
- Active edge functions list

### Not touched

Drive docs (`fitcheck_production_roadmap_v3.docx`, `fitcheck_production_roadmap_v4.docx`, `fitcheck_cowork_prompt_v3.md`) — these are in the Google Drive workspace, not the repo. The stale ref there is in archive-class files; flagging for Amir to handle manually if needed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)