### PR TITLE
release: fix wiring gap + <UNKNOWN> chip + stale ref (#207 #208 #209)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Type check
         run: bun run tsc --noEmit

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,14 @@ pnpm-lock.yaml
 
 # Archived Lovable config
 .lovable-archive/
+
+# Local deployment scripts (one-off .command files)
+*.command
+_patches/
+
+# Bun build info
+tsconfig.app.tsbuildinfo
+tsconfig.node.tsbuildinfo
+
+# Supabase temp
+supabase/.temp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# iCareerOS — Claude Workspace Instructions
+
+> These rules apply to all Claude sessions working in this repo.
+
+## Supabase Project Refs
+
+| Environment | Ref | Name |
+|---|---|---|
+| **Production** | `bryoehuhhhjqcueomgev` | CareerPlatform |
+| **Staging** | `muevgfmpzykihjuihnga` | icareeros-staging (created 2026-04-19) |
+
+⚠️ The ref `gberhsbddthwkjimsqig` (old Lovable project) **no longer exists** in the org. Do not reference it anywhere.
+
+## Branch Policy
+
+- All work targets `dev`. Feature branches from `dev`, PR back to `dev`.
+- **Never push to `main`** — main is protected and deployment-gated.
+- Delete feature branches after merge.
+
+## Stack Quick Reference
+
+| Component | Technology |
+|---|---|
+| Framework | React 18 + TypeScript 5.8 |
+| Build | Vite + Bun |
+| Styling | Tailwind CSS + shadcn/ui |
+| Backend | Supabase (PostgreSQL, Edge Functions, Auth) |
+| Hosting | Vercel (jabri-solutions team) |
+| Payments | Stripe + Stripe Connect |
+| AI | Anthropic Claude |
+| Email | Resend |
+
+## Edge Function Invocation
+
+Always use `supabase.functions.invoke("<fn>", { body })` — never raw `fetch(VITE_SUPABASE_URL/functions/v1/...)`.
+
+Exception: SSE streaming responses (e.g. `mock-interview`) require raw fetch with `resp.body?.getReader()`.
+
+## Active Edge Functions (verified 2026-04-20)
+
+`discover-jobs`, `career-path-analysis`, `match-jobs`, `discovery-agent`, `search-jobs`
+
+## Never
+
+- Commit secrets or `.env` values
+- Modify production schema without explicit approval
+- Touch DNS or registrar settings

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@sentry/react": "^8.0.0",
+        "@sentry/react": "^8.55.1",
         "@supabase/supabase-js": "^2.97.0",
         "@tanstack/react-query": "^5.83.0",
         "class-variance-authority": "^0.7.1",
@@ -70,6 +70,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@sentry/vite-plugin": "^5.2.0",
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.0",
@@ -78,6 +79,7 @@
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
         "@vitejs/plugin-react-swc": "^3.11.0",
+        "@vitest/coverage-v8": "^3.2.4",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.32.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -98,6 +100,8 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.10", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww=="],
 
     "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.9", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg=="],
@@ -106,9 +110,39 @@
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
+    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
@@ -222,7 +256,13 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.6", "", {}, "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
 
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
 
@@ -263,6 +303,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -466,11 +508,37 @@
 
     "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@8.55.1", "", { "dependencies": { "@sentry-internal/replay": "8.55.1", "@sentry/core": "8.55.1" } }, "sha512-2sKRu96Qe70y6TiYdYbwkhg4um2prgzH/ZJRItuoSEAjPjoFYYlP+1qjE2CcBw4RPS8/PimV7SFheSaeZs2GCw=="],
 
+    "@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@5.2.0", "", {}, "sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg=="],
+
     "@sentry/browser": ["@sentry/browser@8.55.1", "", { "dependencies": { "@sentry-internal/browser-utils": "8.55.1", "@sentry-internal/feedback": "8.55.1", "@sentry-internal/replay": "8.55.1", "@sentry-internal/replay-canvas": "8.55.1", "@sentry/core": "8.55.1" } }, "sha512-OEn2eg8h3Mr7BmBGQ28BqbWehYA/NklZ0pAZB1FypPPl+kMd85AbaRdGTnaSjgmpc8bKbBO64edq4Y14sbCs5w=="],
+
+    "@sentry/bundler-plugin-core": ["@sentry/bundler-plugin-core@5.2.0", "", { "dependencies": { "@babel/core": "^7.18.5", "@sentry/babel-plugin-component-annotate": "5.2.0", "@sentry/cli": "^2.58.5", "dotenv": "^16.3.1", "find-up": "^5.0.0", "glob": "^13.0.6", "magic-string": "~0.30.8" } }, "sha512-+C0x4gEIJRgoMwyRFGx+TFiJ1Po2BZlT1v61+PnouiaprKL5qtZG8n5PXx/5LPLDsVjSIcXjnDrTz9aSm8SJ3w=="],
+
+    "@sentry/cli": ["@sentry/cli@2.58.5", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.58.5", "@sentry/cli-linux-arm": "2.58.5", "@sentry/cli-linux-arm64": "2.58.5", "@sentry/cli-linux-i686": "2.58.5", "@sentry/cli-linux-x64": "2.58.5", "@sentry/cli-win32-arm64": "2.58.5", "@sentry/cli-win32-i686": "2.58.5", "@sentry/cli-win32-x64": "2.58.5" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg=="],
+
+    "@sentry/cli-darwin": ["@sentry/cli-darwin@2.58.5", "", { "os": "darwin" }, "sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ=="],
+
+    "@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw=="],
+
+    "@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ=="],
+
+    "@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw=="],
+
+    "@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g=="],
+
+    "@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.58.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA=="],
+
+    "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g=="],
+
+    "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.5", "", { "os": "win32", "cpu": "x64" }, "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg=="],
 
     "@sentry/core": ["@sentry/core@8.55.1", "", {}, "sha512-0ea+yDOgaijR3ba2al1QZxY0bZ9MBZq2a0G+2A0uCBpBkiXnpLFGVAo9UAlEikN1C4M8ROZYiuFU7yZCqacgLQ=="],
 
     "@sentry/react": ["@sentry/react@8.55.1", "", { "dependencies": { "@sentry/browser": "8.55.1", "@sentry/core": "8.55.1", "hoist-non-react-statics": "^3.3.2" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-vrqEI1EVRMaeUluHSt84//WFuMecqAfwS+t2SojhvXtsSP6BbaCHd0jt7til5MBzI9kWAQjIxsUUr3pbFAviVg=="],
+
+    "@sentry/rollup-plugin": ["@sentry/rollup-plugin@5.2.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.2.0", "magic-string": "~0.30.8" }, "peerDependencies": { "rollup": ">=3.2.0" }, "optionalPeers": ["rollup"] }, "sha512-a8LfpvcYMFtFSroro5MpCcOoS528LeLfUHzxWURnpofOnY+Aso9Si4y4dFlna+RKqxCXjmFbn6CLnfI+YrHysQ=="],
+
+    "@sentry/vite-plugin": ["@sentry/vite-plugin@5.2.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.2.0", "@sentry/rollup-plugin": "5.2.0" } }, "sha512-4Jo3ixBspso5HY81PDvZdRXkH9wYGVmcw/0a2IX9ejbyKBdHqkYg4IhAtNqGUAyGuHwwRS9Y1S+sCMvrXv6htw=="],
 
     "@supabase/auth-js": ["@supabase/auth-js@2.103.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A=="],
 
@@ -598,6 +666,8 @@
 
     "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@3.11.0", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-beta.27", "@swc/core": "^1.12.11" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7" } }, "sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w=="],
 
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
+
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
@@ -618,6 +688,8 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -637,6 +709,8 @@
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
 
     "autoprefixer": ["autoprefixer@10.5.0", "", { "dependencies": { "browserslist": "^4.28.2", "caniuse-lite": "^1.0.30001787", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong=="],
 
@@ -691,6 +765,8 @@
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
 
@@ -766,7 +842,11 @@
 
     "dompurify": ["dompurify@3.3.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA=="],
 
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
     "duck": ["duck@0.1.12", "", { "dependencies": { "underscore": "^1.13.1" } }, "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.336", "", {}, "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ=="],
 
@@ -775,6 +855,8 @@
     "embla-carousel-react": ["embla-carousel-react@8.6.0", "", { "dependencies": { "embla-carousel": "8.6.0", "embla-carousel-reactive-utils": "8.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA=="],
 
     "embla-carousel-reactive-utils": ["embla-carousel-reactive-utils@8.6.0", "", { "peerDependencies": { "embla-carousel": "8.6.0" } }, "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -844,13 +926,19 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -866,9 +954,13 @@
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
     "html-parse-stringify": ["html-parse-stringify@3.0.1", "", { "dependencies": { "void-elements": "3.1.0" } }, "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg=="],
 
     "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "i18next": ["i18next@24.2.3", "", { "dependencies": { "@babel/runtime": "^7.26.10" }, "peerDependencies": { "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A=="],
 
@@ -900,6 +992,8 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
@@ -910,6 +1004,16 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -918,11 +1022,15 @@
 
     "jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
 
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jspdf": ["jspdf@4.2.1", "", { "dependencies": { "@babel/runtime": "^7.28.6", "fast-png": "^6.2.0", "fflate": "^0.8.1" }, "optionalDependencies": { "canvg": "^3.0.11", "core-js": "^3.6.0", "dompurify": "^3.3.1", "html2canvas": "^1.0.0-rc.5" } }, "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ=="],
 
@@ -982,6 +1090,10 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
     "mammoth": ["mammoth@1.12.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "argparse": "~1.0.3", "base64-js": "^1.5.1", "bluebird": "~3.4.0", "dingbat-to-unicode": "^1.0.1", "jszip": "^3.7.1", "lop": "^0.4.2", "path-is-absolute": "^1.0.0", "underscore": "^1.13.1", "xmlbuilder": "^10.0.0" }, "bin": { "mammoth": "bin/mammoth" } }, "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w=="],
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
@@ -998,6 +1110,8 @@
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
@@ -1007,6 +1121,8 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "next-themes": ["next-themes@0.3.0", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18", "react-dom": "^16.8 || ^17 || ^18" } }, "sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
@@ -1024,6 +1140,8 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
@@ -1037,6 +1155,8 @@
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -1074,7 +1194,11 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -1164,6 +1288,8 @@
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "sonner": ["sonner@1.7.4", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -1176,7 +1302,15 @@
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
@@ -1199,6 +1333,8 @@
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
 
     "tailwindcss-animate": ["tailwindcss-animate@1.0.7", "", { "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders" } }, "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA=="],
+
+    "test-exclude": ["test-exclude@7.0.2", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^10.2.2" } }, "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw=="],
 
     "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
 
@@ -1290,6 +1426,10 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "xml": ["xml@1.0.1", "", {}, "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="],
@@ -1302,9 +1442,17 @@
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -1354,6 +1502,8 @@
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "ast-v8-to-istanbul/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -1368,11 +1518,15 @@
 
     "fast-png/pako": ["pako@2.1.0", "", {}, "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="],
 
+    "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
@@ -1384,13 +1538,31 @@
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
 
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "tailwindcss/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
+    "test-exclude/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "test-exclude/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
     "vite-node/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
     "vitest/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@types/ws/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
@@ -1398,6 +1570,28 @@
 
     "docx/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "test-exclude/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "test-exclude/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "test-exclude/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "test-exclude/glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "test-exclude/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }
 }

--- a/docs/iCareerOS-Consolidated-Build-Plan.md
+++ b/docs/iCareerOS-Consolidated-Build-Plan.md
@@ -73,7 +73,7 @@ The following decisions resolve all conflicts between the original 11-phase prod
 
 9. **Missing canonical entries:** Skill Store, Skill Radar, Network Tracker, and Career XP are now added to the canonical table above. They are future modules built in Phase 8+ alongside the Crew automation.
 
-10. **Supabase project ref:** Production is bryoehuhhhjqcueomgev (CareerPlatform). The old Lovable ref gberhsbddthwkjimsqig is deprecated and must not be used for any new deployments.
+10. **Supabase project ref:** Production is `bryoehuhhhjqcueomgev` (CareerPlatform). Staging is `muevgfmpzykihjuihnga` (icareeros-staging, created 2026-04-19). The old Lovable ref `gberhsbddthwkjimsqig` no longer exists in the org and must not be referenced anywhere.
 
 ---
 

--- a/src/pages/AutoApply.tsx
+++ b/src/pages/AutoApply.tsx
@@ -102,7 +102,9 @@ export default function AutoApplyPage() {
           jobTitles: ((data as any).target_job_titles as string[]) || [],
           salaryMin: (data as any).salary_min || "",
           salaryMax: (data as any).salary_max || "",
-          locations: (data as any).location ? [(data as any).location] : [],
+          locations: [(data as any).location].filter(
+            (loc): loc is string => !!loc && !/^<[A-Z_]+>$/.test(loc.trim())
+          ),
           remoteOnly: (data as any).remote_only || false,
           requireReview: true,
           minMatchScore: (data as any).min_match_score ?? 60,
@@ -600,11 +602,13 @@ export default function AutoApplyPage() {
                 <Button variant="outline" size="sm" onClick={addLocation}>Add</Button>
               </div>
               <div className="flex flex-wrap gap-2 mt-2">
-                {prefs.locations.map((l, i) => (
-                  <Badge key={i} variant="secondary" className="cursor-pointer" onClick={() => setPrefs({ ...prefs, locations: prefs.locations.filter((_, idx) => idx !== i) })}>
-                    <MapPin className="w-3 h-3 mr-1" />{l} <X className="w-3 h-3 ml-1" />
-                  </Badge>
-                ))}
+                {prefs.locations
+                  .filter(loc => loc && !/^<[A-Z_]+>$/.test(loc.trim()))
+                  .map((l, i) => (
+                    <Badge key={i} variant="secondary" className="cursor-pointer" onClick={() => setPrefs({ ...prefs, locations: prefs.locations.filter((_, idx) => idx !== i) })}>
+                      <MapPin className="w-3 h-3 mr-1" />{l} <X className="w-3 h-3 ml-1" />
+                    </Badge>
+                  ))}
               </div>
             </div>
 

--- a/src/pages/AutoApply.tsx
+++ b/src/pages/AutoApply.tsx
@@ -32,6 +32,7 @@ interface AutoApplyPrefs {
 
 interface QueuedApplication {
   id: string;
+  jobDbId?: string;        // DB id from public.jobs — used for job_queue writes
   jobTitle: string;
   company: string;
   location: string;
@@ -71,6 +72,7 @@ export default function AutoApplyPage() {
   const [locationInput, setLocationInput] = useState("");
   const [queue, setQueue] = useState<QueuedApplication[]>([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [generatingId, setGeneratingId] = useState<string | null>(null);
   const [analyzingId, setAnalyzingId] = useState<string | null>(null);
@@ -202,6 +204,7 @@ export default function AutoApplyPage() {
       return;
     }
     setIsSearching(true);
+    setSearchError(null);
     try {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) { toast.error("Please sign in"); return; }
@@ -212,27 +215,22 @@ export default function AutoApplyPage() {
         .eq("user_id", session.user.id)
         .maybeSingle();
 
-      const resp = await fetch(
-        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/search-jobs`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${session.access_token}`,
-          },
-          body: JSON.stringify({
-            skills: (profile?.skills as string[]) || [],
-            jobTypes: (profile as any)?.preferred_job_types || [],
-            location: prefs.locations.join(", ") || (profile?.location as string) || "",
-            careerLevel: (profile as any)?.career_level || "",
-            targetTitles: prefs.jobTitles,
-            query: prefs.remoteOnly ? "remote positions only" : "",
-          }),
-        }
-      );
+      // Invoke discover-jobs edge function via SDK (auth injected automatically)
+      const { data, error: fnErr } = await supabase.functions.invoke("discover-jobs", {
+        body: {
+          targetTitles: prefs.jobTitles,
+          skills: (profile?.skills as string[]) || [],
+          jobType: ((profile as any)?.preferred_job_types as string[])?.join(",") || undefined,
+          location: prefs.locations.join(", ") || (profile?.location as string) || undefined,
+          careerLevel: (profile as any)?.career_level || undefined,
+          isRemote: prefs.remoteOnly || undefined,
+          userId: session.user.id,
+          triggerMatch: true,
+          limit: 50,
+        },
+      });
 
-      if (!resp.ok) throw new Error("Search failed");
-      const data = await resp.json();
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Search returned no data");
       const jobs = (data.jobs || []) as any[];
 
       const resumeLookup = await getBestResumeText(session.user.id);
@@ -240,16 +238,18 @@ export default function AutoApplyPage() {
 
       const newQueue: QueuedApplication[] = jobs
         .map((job: any) => {
-          const jobDesc = `${job.title} at ${job.company}\nLocation: ${job.location}\nType: ${job.type || ""}\n\n${job.description}`;
+          const jobDesc = `${job.title} at ${job.company}\nLocation: ${job.location}\nType: ${job.job_type || job.type || ""}\n\n${job.description}`;
           const analysis = resumeText ? analyzeJobFit(jobDesc, resumeText) : null;
-          const score = analysis?.overallScore || 50;
+          // Prefer server-side fit_score; fall back to local analysis score
+          const score = job.fit_score ?? analysis?.overallScore ?? job.quality_score ?? 50;
           return {
             id: crypto.randomUUID(),
+            jobDbId: job.id || undefined,
             jobTitle: job.title,
             company: job.company,
             location: job.location,
-            matchScore: score,
-            status: score >= prefs.minMatchScore ? "review" as const : "skipped" as const,
+            matchScore: Math.round(score),
+            status: Math.round(score) >= prefs.minMatchScore ? "review" as const : "skipped" as const,
             jobDescription: jobDesc,
             analysis,
           };
@@ -258,7 +258,22 @@ export default function AutoApplyPage() {
 
       setQueue((prev) => [...newQueue, ...prev]);
       addLog("Search complete", `Found ${newQueue.filter(j => j.status === "review").length} matching jobs`, "search");
-      
+
+      // Persist review-eligible jobs to job_queue so Supabase tracks them
+      const reviewJobs = newQueue.filter(j => j.status === "review" && j.jobDbId);
+      if (reviewJobs.length > 0) {
+        const { error: qErr } = await supabase.from("job_queue").insert(
+          reviewJobs.map(j => ({
+            job_id: j.jobDbId!,
+            user_id: session.user.id,
+            type: "auto_apply",
+            status: "pending",
+            payload: { matchScore: j.matchScore, jobTitle: j.jobTitle, company: j.company },
+          }))
+        );
+        if (qErr) logger.warn("[AutoApply] job_queue insert partial error:", qErr.message);
+      }
+
       // Smart/Auto mode: auto-approve high matches
       if (prefs.applyMode === "smart" || prefs.applyMode === "full-auto") {
         const threshold = prefs.applyMode === "full-auto" ? prefs.minMatchScore : 80;
@@ -268,14 +283,20 @@ export default function AutoApplyPage() {
           }
         }
       }
-      
-      if (resumeLookup.source === "profile") {
-        toast.success(`Found ${newQueue.filter(j => j.status === "review").length} jobs. Using your profile for fit analysis.`);
+
+      const reviewCount = newQueue.filter(j => j.status === "review").length;
+      if (reviewCount === 0) {
+        toast.info(`No jobs met your ${prefs.minMatchScore}% threshold. Try lowering it or broadening your titles.`);
+      } else if (resumeLookup.source === "profile") {
+        toast.success(`Found ${reviewCount} jobs. Using your profile for fit analysis.`);
       } else {
-        toast.success(`Found ${newQueue.filter(j => j.status === "review").length} jobs above ${prefs.minMatchScore}% threshold`);
+        toast.success(`Found ${reviewCount} jobs above ${prefs.minMatchScore}% threshold`);
       }
-    } catch {
-      toast.error("Auto-search failed");
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Auto-search failed";
+      setSearchError(msg);
+      toast.error("Queue failed. Please retry.");
+      logger.error("[AutoApply] runAutoSearch error:", e);
     } finally {
       setIsSearching(false);
     }
@@ -639,6 +660,23 @@ export default function AutoApplyPage() {
             )}
           </div>
         </Card>
+
+        {/* Search error state */}
+        {searchError && !isSearching && (
+          <div className="text-center py-8 text-destructive">
+            <p className="font-medium mb-1">Queue failed. Please retry.</p>
+            <p className="text-sm text-muted-foreground">{searchError}</p>
+          </div>
+        )}
+
+        {/* Zero-matches state */}
+        {!isSearching && !searchError && queue.length === 0 && profileLoaded && (
+          <div className="text-center py-8 text-muted-foreground">
+            <Search className="w-10 h-10 mx-auto mb-3 opacity-30" />
+            <p className="font-medium">No matching jobs found</p>
+            <p className="text-sm mt-1">Try adding more job titles or lowering your minimum match score.</p>
+          </div>
+        )}
 
         {/* Application Queue */}
         {queue.length > 0 && (

--- a/src/pages/Career.tsx
+++ b/src/pages/Career.tsx
@@ -34,6 +34,7 @@ export default function CareerPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [analyzing, setAnalyzing] = useState(false);
+  const [careerError, setCareerError] = useState<string | null>(null);
   const [insight, setInsight] = useState<CareerInsight | null>(null);
   const [editingGoals, setEditingGoals] = useState(false);
 
@@ -100,6 +101,7 @@ export default function CareerPage() {
 
   const analyzeCareer = async () => {
     setAnalyzing(true);
+    setCareerError(null);
     try {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) { toast.error("Please sign in"); return; }
@@ -112,10 +114,9 @@ export default function CareerPage() {
 
       const { data: history } = await supabase.from("analysis_history" as any).select("job_title, overall_score, gaps, matched_skills").eq("user_id", session.user.id).order("created_at", { ascending: false }).limit(5) as any;
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/career-path-analysis`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({
+      // Invoke career-path-analysis via SDK (replaces raw fetch — auth injected automatically)
+      const { data, error: fnErr } = await supabase.functions.invoke("career-path-analysis", {
+        body: {
           skills: profile.skills,
           careerLevel: (profile as any).career_level,
           experience: profile.work_experience,
@@ -124,12 +125,19 @@ export default function CareerPage() {
           targetTitles: (profile as any).target_job_titles,
           recentAnalyses: history || [],
           includeRoadmap: true,
-        }),
+        },
       });
-      if (!resp.ok) throw new Error("Analysis failed");
-      setInsight(await resp.json());
-    } catch { toast.error("Failed to analyze career path"); }
-    finally { setAnalyzing(false); }
+
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Roadmap generation failed");
+      setInsight(data as CareerInsight);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Roadmap failed";
+      setCareerError(msg);
+      toast.error("Roadmap failed. Please retry.");
+      logger.error("[Career] analyzeCareer error:", e);
+    } finally {
+      setAnalyzing(false);
+    }
   };
 
   if (loading) return <div className="min-h-screen bg-background flex items-center justify-center"><Loader2 className="w-8 h-8 animate-spin text-accent" /></div>;
@@ -226,12 +234,19 @@ export default function CareerPage() {
             </Button>
           </div>
 
-          {!insight ? (
+          {careerError && !analyzing && (
+            <div className="text-center py-8 text-destructive">
+              <p className="font-medium mb-1">Roadmap failed. Please retry.</p>
+              <p className="text-sm text-muted-foreground">{careerError}</p>
+            </div>
+          )}
+
+          {!insight && !careerError ? (
             <div className="text-center py-8">
               <Map className="w-12 h-12 text-muted-foreground mx-auto mb-3" />
-              <p className="text-muted-foreground">Generate your personalized career roadmap based on your profile, skills, and market data.</p>
+              <p className="text-muted-foreground">{analyzing ? "Generating roadmap…" : "Generate your personalized career roadmap based on your profile, skills, and market data."}</p>
             </div>
-          ) : (
+          ) : insight ? (
             <div className="space-y-6">
               {/* Current Level */}
               <div className="flex items-center gap-3 p-3 rounded-lg bg-accent/5 border border-accent/20">
@@ -308,7 +323,7 @@ export default function CareerPage() {
                 <p className="text-sm text-foreground leading-relaxed">{insight.advice}</p>
               </Card>
             </div>
-          )}
+          ) : null}
         </Card>
 
         {/* Salary Projections */}

--- a/src/pages/JobSearch.tsx
+++ b/src/pages/JobSearch.tsx
@@ -375,6 +375,7 @@ export default function JobSearchPage() {
     };
 
     let triggeredMatch = false;
+    let rawJobsCount = 0;
 
     // Fetch + score via the shell orchestrator (steps 1 + 2).
     // JobSearch must NOT call searchJobs / scoreJobs directly — all service
@@ -383,6 +384,7 @@ export default function JobSearchPage() {
     try {
       const result = await runSearchOnly(filters, historicalOutcomes);
       enriched = result.jobs;
+      rawJobsCount = result.jobs.length;
       triggeredMatch = result.matchingTriggered;
     } catch (e) {
       logger.error("[JobSearch] error:", e);
@@ -415,7 +417,7 @@ export default function JobSearchPage() {
 
     if (!enriched.length && beforeCount > 0) {
       toast.info(`${beforeCount} jobs found but hidden by your ${effectiveMinFit}% fit score filter.`);
-    } else if (!enriched.length && rawJobs.length > 0) {
+    } else if (!enriched.length && rawJobsCount > 0) {
       toast.info("Jobs found but all filtered out.");
     } else if (!enriched.length) {
       toast.info("No jobs found. Try adjusting your criteria.");

--- a/src/pages/JobSearch.tsx
+++ b/src/pages/JobSearch.tsx
@@ -294,6 +294,8 @@ export default function JobSearchPage() {
   // Results
   const [jobs, setJobs] = useState<EnrichedJob[]>([]);
   const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [searchRan, setSearchRan] = useState(false); // true once any search has completed
   const [matchingInProgress, setMatchingInProgress] = useState(false);
   const [totalBeforeFilter, setTotalBeforeFilter] = useState(0);
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
@@ -364,6 +366,7 @@ export default function JobSearchPage() {
   const handleSearch = async (overrideFilters?: Partial<JobSearchFilters>) => {
     if (pollTimerRef.current) { clearTimeout(pollTimerRef.current); pollTimerRef.current = null; }
     setSearching(true);
+    setSearchError(null);
     setJobs([]);
     setMatchingInProgress(false);
 
@@ -388,7 +391,9 @@ export default function JobSearchPage() {
       triggeredMatch = result.matchingTriggered;
     } catch (e) {
       logger.error("[JobSearch] error:", e);
-      toast.error("Search encountered an issue.");
+      const msg = e instanceof Error ? e.message : "Search encountered an issue.";
+      setSearchError(msg);
+      toast.error("Search failed. Please retry.");
     }
 
     // Filter out ignored / already-saved
@@ -423,6 +428,7 @@ export default function JobSearchPage() {
       toast.info("No jobs found. Try adjusting your criteria.");
     }
 
+    setSearchRan(true);
     setSearching(false);
 
     // Schedule poll for AI scores if match was triggered
@@ -640,7 +646,7 @@ export default function JobSearchPage() {
             </div>
 
             <Button className="gradient-indigo text-white shadow-indigo-500/20 hover:opacity-90 w-full sm:w-auto" disabled={searching} onClick={() => handleSearch()}>
-              {searching ? <><Loader2 className="w-4 h-4 animate-spin mr-2" />Searching...</> : <><Search className="w-4 h-4 mr-2" />Search Jobs</>}
+              {searching ? <><Loader2 className="w-4 h-4 animate-spin mr-2" />Scanning live jobs…</> : <><Search className="w-4 h-4 mr-2" />Search Jobs</>}
             </Button>
           </div>
         </Card>
@@ -720,15 +726,26 @@ export default function JobSearchPage() {
           </div>
         )}
 
-        {/* Empty state */}
-        {!searching && jobs.length === 0 && profileLoaded && (
+        {/* Empty states — four distinct cases */}
+
+        {/* api-error: search threw */}
+        {!searching && searchError && (
+          <div className="text-center py-16 text-destructive">
+            <Search className="w-12 h-12 mx-auto mb-4 opacity-40" />
+            <p className="text-lg mb-2">Search failed. Please retry.</p>
+            <p className="text-sm text-muted-foreground mb-4">{searchError}</p>
+            <Button variant="outline" onClick={() => handleSearch()}>Retry</Button>
+          </div>
+        )}
+
+        {/* idle: no search run yet */}
+        {!searching && !searchError && !searchRan && profileLoaded && (
           <div className="text-center py-16 text-muted-foreground">
             <Search className="w-12 h-12 mx-auto mb-4 opacity-30" />
             {skills.length > 0 || targetTitles.length > 0 ? (
               <>
-                <p className="text-lg mb-2">No jobs matched your filters</p>
-                <p className="text-sm mb-4">Try lowering the minimum fit score, removing location, or broadening job types</p>
-                <Button variant="outline" onClick={() => handleSearch({ minFitScore: 0, showFlagged: true, careerLevel: "" })}>Browse all jobs</Button>
+                <p className="text-lg mb-2">Ready to scan</p>
+                <p className="text-sm mb-4">Click Search Jobs to find live matches for your profile.</p>
               </>
             ) : (
               <>
@@ -737,6 +754,16 @@ export default function JobSearchPage() {
                 <Button variant="outline" onClick={() => handleSearch({ skills: [], targetTitles: [], minFitScore: 0, careerLevel: "" })}>Browse all →</Button>
               </>
             )}
+          </div>
+        )}
+
+        {/* zero-matches: search completed, no results */}
+        {!searching && !searchError && searchRan && jobs.length === 0 && (
+          <div className="text-center py-16 text-muted-foreground">
+            <Search className="w-12 h-12 mx-auto mb-4 opacity-30" />
+            <p className="text-lg mb-2">No jobs matched your filters</p>
+            <p className="text-sm mb-4">Try broadening your criteria — lower the fit score, remove the location filter, or add more job titles.</p>
+            <Button variant="outline" onClick={() => handleSearch({ minFitScore: 0, showFlagged: true, careerLevel: "" })}>Browse all jobs</Button>
           </div>
         )}
       </div>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,4 +1,4 @@
-project_id = "gberhsbddthwkjimsqig"
+project_id = "bryoehuhhhjqcueomgev"
 
 [functions.rewrite-resume]
 verify_jwt = false

--- a/supabase/functions/export-my-data/index.ts
+++ b/supabase/functions/export-my-data/index.ts
@@ -105,11 +105,54 @@ serve(async (req) => {
     ignored_jobs: getData(ignoredJobs),
   };
 
-  return new Response(JSON.stringify(exportData, null, 2), {
+  // Attempt AES-GCM encryption if EXPORT_ENCRYPTION_KEY is configured.
+  // If encryption fails (e.g. key format error), fall back to plain JSON gracefully.
+  const EXPORT_ENCRYPTION_KEY = Deno.env.get("EXPORT_ENCRYPTION_KEY");
+  const dateStr = new Date().toISOString().split("T")[0];
+
+  let responseBody = JSON.stringify(exportData, null, 2);
+  let contentType = "application/json";
+  let filename = `my_data_export_${dateStr}.json`;
+
+  if (EXPORT_ENCRYPTION_KEY) {
+    try {
+      const rawKey = new TextEncoder().encode(
+        EXPORT_ENCRYPTION_KEY.slice(0, 32).padEnd(32, "0")
+      );
+      const key = await crypto.subtle.importKey(
+        "raw",
+        rawKey,
+        { name: "AES-GCM" },
+        false,
+        ["encrypt"]
+      );
+
+      const iv = crypto.getRandomValues(new Uint8Array(12));
+      const encrypted = await crypto.subtle.encrypt(
+        { name: "AES-GCM", iv },
+        key,
+        new TextEncoder().encode(responseBody)
+      );
+
+      // Prepend IV so the client can decrypt: first 12 bytes = IV, rest = ciphertext
+      const combined = new Uint8Array(12 + encrypted.byteLength);
+      combined.set(iv, 0);
+      combined.set(new Uint8Array(encrypted), 12);
+
+      responseBody = btoa(String.fromCharCode(...combined));
+      contentType = "application/octet-stream";
+      filename = `my_data_export_${dateStr}.enc`;
+    } catch (e) {
+      console.error("GDPR export encryption failed, sending unencrypted:", e);
+      // Fall through — plain JSON is better than a broken export
+    }
+  }
+
+  return new Response(responseBody, {
     headers: {
       ...corsHeaders,
-      "Content-Type": "application/json",
-      "Content-Disposition": `attachment; filename="my_data_export_${new Date().toISOString().split("T")[0]}.json"`,
+      "Content-Type": contentType,
+      "Content-Disposition": `attachment; filename="${filename}"`,
     },
   });
 });

--- a/supabase/migrations/20260416_discovery_feature_flags.sql
+++ b/supabase/migrations/20260416_discovery_feature_flags.sql
@@ -1,0 +1,19 @@
+-- =============================================================================
+-- Discovery Agent: per-board feature flags
+-- Migration: 20260416_discovery_feature_flags.sql
+--
+-- Master switch + one flag per board adapter.
+-- All board flags default to false — flip them ON one at a time from
+-- /admin/settings after verifying each adapter's data quality.
+-- =============================================================================
+
+INSERT INTO feature_flags (key, enabled, description) VALUES
+  ('discovery_agent',              true,  'Master switch for Discovery Agent and all board adapters'),
+  ('discovery_board_remoteok',     false, 'Enable RemoteOK job board adapter'),
+  ('discovery_board_weworkremotely', false, 'Enable WeWorkRemotely adapter'),
+  ('discovery_board_greenhouse',   false, 'Enable Greenhouse (employer ATS) adapter'),
+  ('discovery_board_lever',        false, 'Enable Lever (employer ATS) adapter'),
+  ('discovery_board_usajobs',      false, 'Enable USAJobs.gov official API adapter'),
+  ('discovery_board_adzuna',       false, 'Enable Adzuna official API adapter'),
+  ('discovery_cache_enabled',      true,  'Cache scraper results for 6 hours to protect upstream boards')
+ON CONFLICT (key) DO UPDATE SET description = EXCLUDED.description;

--- a/supabase/migrations/20260416_scraped_jobs_discovery.sql
+++ b/supabase/migrations/20260416_scraped_jobs_discovery.sql
@@ -1,0 +1,93 @@
+-- =============================================================================
+-- Discovery Agent: staging table + scraper run log
+-- Migration: 20260416_scraped_jobs_discovery.sql
+--
+-- WHY a new table instead of touching scraped_jobs:
+--   `scraped_jobs` is an active VIEW over `job_postings` (the Python scraper
+--   table). The frontend queries it directly; the bridge cron reads it.
+--   Dropping it would break both. Instead we create `discovery_jobs` as a
+--   clean staging table for the TS board adapters. The existing
+--   bridge_jobs_to_discovered() function is extended (in
+--   20260418_bridge_jobs_to_discovered.sql) to also read discovery_jobs.
+--
+-- Tables created here:
+--   discovery_jobs  — one row per job fetched by a board adapter
+--   scraper_runs    — one row per adapter invocation (observability)
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. discovery_jobs — staging table written by the Discovery Agent adapters.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS discovery_jobs (
+  id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at       timestamptz DEFAULT now(),
+  source_board     text        NOT NULL,   -- 'remoteok', 'greenhouse', 'lever', etc.
+  source_url       text,
+  external_id      text,
+  title            text,
+  company          text,
+  location         text,
+  remote_type      text,                   -- 'remote' | 'hybrid' | 'onsite' | null
+  employment_type  text,                   -- 'full_time' | 'part_time' | 'contract' | 'internship'
+  salary_min       integer,
+  salary_max       integer,
+  salary_currency  text        DEFAULT 'USD',
+  description      text,
+  description_html text,
+  posted_at        timestamptz,
+  scraped_at       timestamptz DEFAULT now(),
+  dedupe_hash      text,
+  raw_payload      jsonb
+);
+
+-- Dedupe: same job on the same board never inserted twice across runs.
+CREATE UNIQUE INDEX IF NOT EXISTS discovery_jobs_dedupe_hash_idx
+  ON discovery_jobs (dedupe_hash)
+  WHERE dedupe_hash IS NOT NULL;
+
+-- Common query patterns.
+CREATE INDEX IF NOT EXISTS discovery_jobs_source_board_scraped_at_idx
+  ON discovery_jobs (source_board, scraped_at DESC);
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX IF NOT EXISTS discovery_jobs_title_trgm_idx
+  ON discovery_jobs USING gin (title gin_trgm_ops);
+
+-- RLS: authenticated users can read; only service role may write.
+ALTER TABLE discovery_jobs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "discovery_jobs readable by authenticated users" ON discovery_jobs;
+CREATE POLICY "discovery_jobs readable by authenticated users"
+  ON discovery_jobs FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+-- ---------------------------------------------------------------------------
+-- 2. scraper_runs — audit log for every adapter invocation.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS scraper_runs (
+  id                        uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_board              text        NOT NULL,
+  search_term               text,
+  location                  text,
+  started_at                timestamptz DEFAULT now(),
+  finished_at               timestamptz,
+  status                    text        CHECK (status IN ('running','success','partial','failed')),
+  jobs_found                integer     DEFAULT 0,
+  jobs_inserted             integer     DEFAULT 0,
+  jobs_skipped_duplicate    integer     DEFAULT 0,
+  error_message             text,
+  http_status               integer
+);
+
+CREATE INDEX IF NOT EXISTS scraper_runs_board_started_idx
+  ON scraper_runs (source_board, started_at DESC);
+
+ALTER TABLE scraper_runs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "scraper_runs readable by admins" ON scraper_runs;
+CREATE POLICY "scraper_runs readable by admins"
+  ON scraper_runs FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM user_roles
+    WHERE user_id = auth.uid() AND role = 'admin'
+  ));

--- a/supabase/migrations/20260418_bridge_jobs_to_discovered.sql
+++ b/supabase/migrations/20260418_bridge_jobs_to_discovered.sql
@@ -1,0 +1,396 @@
+-- =============================================================================
+-- Bridge scraped_jobs + job_postings → discovered_jobs
+-- Migration: 20260418_bridge_jobs_to_discovered.sql
+--
+-- WHY THIS EXISTS:
+--   The frontend (OpportunityRadar, job-service.ts) reads ONLY from
+--   `discovered_jobs` (per-user, relevance-scored table).
+--
+--   Two pipelines populate upstream tables but have no path to users:
+--     1. GitHub Actions scraper  → job_postings  (every 2h, runs fine)
+--     2. Discovery Agent TS fn   → scraped_jobs  (multi-board ATS adapters)
+--
+--   This migration creates a bridge function that:
+--     a. Reads from BOTH job_postings and scraped_jobs
+--     b. Matches jobs against each user's target_titles preferences
+--     c. Scores matches with a heuristic (title + recency + remote + salary)
+--     d. Upserts into discovered_jobs so users immediately see results
+--
+--   A pg_cron job runs the bridge every 30 minutes.
+--   A one-time backfill runs immediately on migration deploy.
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- 1. Register board/scraper sources missing from job_source_config
+--    (FK constraint on discovered_jobs.source_name requires these rows)
+-- ---------------------------------------------------------------------------
+INSERT INTO job_source_config (source_name, source_type, base_url, priority, is_aggregator)
+VALUES
+  ('google',         'scrape', 'https://www.google.com/jobs', 75, true),
+  ('zip_recruiter',  'scrape', 'https://www.ziprecruiter.com', 70, false),
+  ('remoteok',       'scrape', 'https://remoteok.com',        80, false),
+  ('greenhouse',     'scrape', NULL,                          85, false),
+  ('lever',          'scrape', NULL,                          85, false),
+  ('usajobs',        'api',    'https://data.usajobs.gov',    90, false),
+  ('adzuna',         'api',    'https://api.adzuna.com',      75, false),
+  ('scraper',        'scrape', NULL,                          60, false)
+ON CONFLICT (source_name) DO NOTHING;
+
+
+-- ---------------------------------------------------------------------------
+-- 2. Helpers shared by both bridge sources
+-- ---------------------------------------------------------------------------
+
+-- Map job_postings.job_type → discovered_jobs.employment_type
+CREATE OR REPLACE FUNCTION _map_job_type(p text)
+RETURNS text LANGUAGE sql IMMUTABLE STRICT AS $$
+  SELECT CASE lower(trim(p))
+    WHEN 'fulltime'  THEN 'full_time'  WHEN 'full-time'  THEN 'full_time'
+    WHEN 'full_time' THEN 'full_time'  WHEN 'parttime'   THEN 'part_time'
+    WHEN 'part-time' THEN 'part_time'  WHEN 'part_time'  THEN 'part_time'
+    WHEN 'contract'  THEN 'contract'   WHEN 'contractor' THEN 'contract'
+    WHEN 'internship' THEN 'internship' WHEN 'intern'    THEN 'internship'
+    WHEN 'temporary' THEN 'temporary'  WHEN 'temp'       THEN 'temporary'
+    ELSE 'unknown'
+  END;
+$$;
+
+-- Map boolean is_remote → location_type
+CREATE OR REPLACE FUNCTION _map_location_type(p_remote boolean)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE WHEN p_remote IS TRUE THEN 'remote'
+              WHEN p_remote IS FALSE THEN 'onsite'
+              ELSE 'unknown' END;
+$$;
+
+-- Normalise scraper source string → valid job_source_config.source_name
+CREATE OR REPLACE FUNCTION _norm_source(p text)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE lower(trim(p))
+    WHEN 'indeed'         THEN 'indeed'
+    WHEN 'google'         THEN 'google'
+    WHEN 'zip_recruiter'  THEN 'zip_recruiter'
+    WHEN 'ziprecruiter'   THEN 'zip_recruiter'
+    WHEN 'linkedin'       THEN 'linkedin'
+    WHEN 'glassdoor'      THEN 'glassdoor'
+    WHEN 'dice'           THEN 'dice'
+    WHEN 'remoteok'       THEN 'remoteok'
+    WHEN 'greenhouse'     THEN 'greenhouse'
+    WHEN 'lever'          THEN 'lever'
+    WHEN 'usajobs'        THEN 'usajobs'
+    WHEN 'adzuna'         THEN 'adzuna'
+    ELSE 'scraper'
+  END;
+$$;
+
+
+-- ---------------------------------------------------------------------------
+-- 3. Core bridge function
+--    Processes both job_postings (Python scraper) and scraped_jobs (TS agent).
+--    For each active user: matches title, scores, upserts to discovered_jobs.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION bridge_jobs_to_discovered(
+  p_user_id        uuid    DEFAULT NULL,
+  p_max_per_user   integer DEFAULT 200,
+  p_lookback_hours integer DEFAULT 48     -- how far back to look in source tables
+)
+RETURNS TABLE (
+  out_user_id  uuid,
+  from_postings  integer,
+  from_scraped   integer,
+  skipped        integer
+)
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_prefs         RECORD;
+  v_job           RECORD;
+  v_score         numeric;
+  v_days_old      numeric;
+  v_dedup_hash    text;
+  v_batch_id      uuid;
+  v_cnt_postings  integer;
+  v_cnt_scraped   integer;
+  v_cnt_skipped   integer;
+  v_tsquery       tsquery;
+  v_source_norm   text;
+  v_cutoff        timestamptz;
+BEGIN
+  v_cutoff := now() - (p_lookback_hours || ' hours')::interval;
+
+  FOR v_prefs IN
+    SELECT
+      usp.user_id,
+      COALESCE(usp.target_titles, ARRAY[]::text[])              AS titles,
+      usp.remote_preference,
+      usp.salary_min                                             AS u_sal_min,
+      usp.salary_max                                             AS u_sal_max
+    FROM user_search_preferences usp
+    WHERE usp.alerts_enabled = true
+      AND (p_user_id IS NULL OR usp.user_id = p_user_id)
+  LOOP
+    v_cnt_postings := 0;
+    v_cnt_scraped  := 0;
+    v_cnt_skipped  := 0;
+    v_batch_id     := gen_random_uuid();
+
+    -- Build tsquery (best effort; fall back to NULL = accept all)
+    BEGIN
+      IF array_length(v_prefs.titles, 1) > 0 THEN
+        v_tsquery := to_tsquery('english',
+          array_to_string(
+            ARRAY(SELECT DISTINCT
+              regexp_replace(regexp_replace(unnest(v_prefs.titles), '[^a-zA-Z0-9 ]', '', 'g'), '\s+', ' | ', 'g')
+            ), ' | '));
+      ELSE
+        v_tsquery := NULL;
+      END IF;
+    EXCEPTION WHEN OTHERS THEN v_tsquery := NULL;
+    END;
+
+    -- ---- SOURCE 1: job_postings (GitHub Actions Python scraper) ----
+    FOR v_job IN
+      SELECT
+        j.external_id,
+        j.title,
+        j.company,
+        j.location,
+        j.is_remote,
+        j.job_type,
+        j.salary_min,
+        j.salary_max,
+        j.salary_currency,
+        j.description,
+        j.job_url      AS source_url,
+        j.source,
+        j.date_posted,
+        j.scraped_at
+      FROM job_postings j
+      WHERE j.scraped_at > v_cutoff
+        AND (j.expires_at IS NULL OR j.expires_at > now())
+        AND (
+          array_length(v_prefs.titles, 1) IS NULL
+          OR array_length(v_prefs.titles, 1) = 0
+          OR (v_tsquery IS NOT NULL
+              AND to_tsvector('english', coalesce(j.title,'') || ' ' || coalesce(j.description,''))
+                  @@ v_tsquery)
+          OR EXISTS (
+            SELECT 1 FROM unnest(v_prefs.titles) t(tit)
+            WHERE j.title ILIKE '%' || t.tit || '%'
+               OR t.tit  ILIKE '%' || j.title || '%'
+          )
+        )
+      ORDER BY j.scraped_at DESC, j.date_posted DESC NULLS LAST
+      LIMIT p_max_per_user
+    LOOP
+      v_days_old    := EXTRACT(EPOCH FROM (now() - COALESCE(v_job.date_posted, v_job.scraped_at))) / 86400.0;
+      v_score       := _score_job(v_job.title, v_days_old, v_job.is_remote::boolean,
+                                   v_job.salary_min, v_job.salary_max,
+                                   v_prefs.titles, v_prefs.remote_preference,
+                                   v_prefs.u_sal_min, v_prefs.u_sal_max,
+                                   _norm_source(v_job.source));
+      v_source_norm := _norm_source(v_job.source);
+      BEGIN
+        INSERT INTO discovered_jobs (
+          user_id, external_id, source_name, source_url, title, title_normalized,
+          company_name, description, location, location_type, salary_min, salary_max,
+          salary_currency, employment_type, experience_level, posted_at,
+          relevance_score, score_breakdown, score_explanation, trust_score, status,
+          discovery_batch_id, first_seen_at, last_seen_at, raw_data
+        ) VALUES (
+          v_prefs.user_id, v_job.external_id, v_source_norm, v_job.source_url,
+          v_job.title, lower(trim(v_job.title)), v_job.company, v_job.description,
+          v_job.location, _map_location_type(v_job.is_remote), v_job.salary_min,
+          v_job.salary_max, COALESCE(v_job.salary_currency,'USD'),
+          _map_job_type(v_job.job_type), 'unknown', v_job.date_posted,
+          v_score, '{}'::jsonb,
+          'Score '||round(v_score)||' via scraper ('||v_source_norm||')',
+          75.0, 'scored', v_batch_id, now(), now(),
+          jsonb_build_object('source','job_postings','scraped_at',v_job.scraped_at)
+        )
+        ON CONFLICT (user_id, dedup_hash) DO UPDATE
+          SET relevance_score = GREATEST(discovered_jobs.relevance_score, EXCLUDED.relevance_score),
+              last_seen_at    = now();
+        v_cnt_postings := v_cnt_postings + 1;
+      EXCEPTION WHEN OTHERS THEN
+        v_cnt_skipped := v_cnt_skipped + 1;
+      END;
+    END LOOP;
+
+    -- ---- SOURCE 2: discovery_jobs (Discovery Agent TS board adapters) ----
+    -- NOTE: scraped_jobs is a VIEW over job_postings (Python scraper) and must
+    -- not be touched. Discovery Agent writes to discovery_jobs (real table).
+    FOR v_job IN
+      SELECT
+        s.external_id,
+        s.title,
+        s.company,
+        s.location,
+        (s.remote_type = 'remote')                 AS is_remote,
+        s.employment_type                           AS job_type,
+        s.salary_min,
+        s.salary_max,
+        s.salary_currency,
+        s.description,
+        s.source_url,
+        s.source_board                              AS source,
+        s.posted_at                                 AS date_posted,
+        s.scraped_at
+      FROM discovery_jobs s
+      WHERE s.scraped_at > v_cutoff
+        AND (
+          array_length(v_prefs.titles, 1) IS NULL
+          OR array_length(v_prefs.titles, 1) = 0
+          OR (v_tsquery IS NOT NULL
+              AND to_tsvector('english', coalesce(s.title,'') || ' ' || coalesce(s.description,''))
+                  @@ v_tsquery)
+          OR EXISTS (
+            SELECT 1 FROM unnest(v_prefs.titles) t(tit)
+            WHERE s.title ILIKE '%' || t.tit || '%'
+               OR t.tit  ILIKE '%' || s.title || '%'
+          )
+        )
+      ORDER BY s.scraped_at DESC, s.posted_at DESC NULLS LAST
+      LIMIT p_max_per_user
+    LOOP
+      v_days_old    := EXTRACT(EPOCH FROM (now() - COALESCE(v_job.date_posted, v_job.scraped_at))) / 86400.0;
+      v_score       := _score_job(v_job.title, v_days_old, v_job.is_remote,
+                                   v_job.salary_min, v_job.salary_max,
+                                   v_prefs.titles, v_prefs.remote_preference,
+                                   v_prefs.u_sal_min, v_prefs.u_sal_max,
+                                   _norm_source(v_job.source));
+      v_source_norm := _norm_source(v_job.source);
+      BEGIN
+        INSERT INTO discovered_jobs (
+          user_id, external_id, source_name, source_url, title, title_normalized,
+          company_name, description, location, location_type, salary_min, salary_max,
+          salary_currency, employment_type, experience_level, posted_at,
+          relevance_score, score_breakdown, score_explanation, trust_score, status,
+          discovery_batch_id, first_seen_at, last_seen_at, raw_data
+        ) VALUES (
+          v_prefs.user_id, v_job.external_id, v_source_norm, v_job.source_url,
+          v_job.title, lower(trim(v_job.title)), v_job.company, v_job.description,
+          v_job.location,
+          COALESCE(CASE WHEN v_job.is_remote THEN 'remote' ELSE 'onsite' END, 'unknown'),
+          v_job.salary_min, v_job.salary_max, COALESCE(v_job.salary_currency,'USD'),
+          COALESCE(v_job.job_type, 'unknown'), 'unknown', v_job.date_posted,
+          v_score, '{}'::jsonb,
+          'Score '||round(v_score)||' via discovery-agent ('||v_source_norm||')',
+          85.0, 'scored', v_batch_id, now(), now(),
+          jsonb_build_object('source','discovery_jobs','scraped_at',v_job.scraped_at)
+        )
+        ON CONFLICT (user_id, dedup_hash) DO UPDATE
+          SET relevance_score = GREATEST(discovered_jobs.relevance_score, EXCLUDED.relevance_score),
+              last_seen_at    = now();
+        v_cnt_scraped := v_cnt_scraped + 1;
+      EXCEPTION WHEN OTHERS THEN
+        v_cnt_skipped := v_cnt_skipped + 1;
+      END;
+    END LOOP;
+
+    out_user_id   := v_prefs.user_id;
+    from_postings := v_cnt_postings;
+    from_scraped  := v_cnt_scraped;
+    skipped       := v_cnt_skipped;
+    RETURN NEXT;
+  END LOOP;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Inline scoring helper (extracted so bridge body stays readable)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION _score_job(
+  p_title          text,
+  p_days_old       numeric,
+  p_is_remote      boolean,
+  p_sal_min        numeric,
+  p_sal_max        numeric,
+  p_target_titles  text[],
+  p_remote_pref    text,
+  p_u_sal_min      numeric,
+  p_u_sal_max      numeric,
+  p_source         text
+) RETURNS numeric LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+  v_title_score  numeric := 10;
+  v_recency      numeric;
+  v_remote       numeric := 0;
+  v_salary       numeric := 0;
+  v_src          numeric;
+BEGIN
+  -- Title match (0–40)
+  IF EXISTS (SELECT 1 FROM unnest(p_target_titles) t(tit) WHERE lower(p_title) = lower(t.tit)) THEN
+    v_title_score := 40;
+  ELSIF EXISTS (SELECT 1 FROM unnest(p_target_titles) t(tit) WHERE lower(p_title) ILIKE '%' || lower(t.tit) || '%') THEN
+    v_title_score := 30;
+  ELSIF array_length(p_target_titles, 1) IS NULL OR array_length(p_target_titles, 1) = 0 THEN
+    v_title_score := 20;
+  END IF;
+
+  -- Recency (0–20)
+  v_recency := GREATEST(0, 20.0 * (1.0 - (COALESCE(p_days_old, 30) / 30.0)));
+
+  -- Remote match (0–15)
+  v_remote := CASE
+    WHEN p_remote_pref = 'remote'  AND p_is_remote = true  THEN 15
+    WHEN p_remote_pref = 'onsite'  AND p_is_remote = false THEN 15
+    WHEN p_remote_pref = 'any'                              THEN  8
+    ELSE 5
+  END;
+
+  -- Salary (0–15)
+  IF p_u_sal_min IS NOT NULL AND p_sal_max IS NOT NULL AND p_sal_max >= p_u_sal_min THEN
+    v_salary := 15;
+  ELSIF p_u_sal_min IS NULL THEN
+    v_salary := 5;
+  END IF;
+
+  -- Source quality (0–10)
+  v_src := CASE p_source
+    WHEN 'greenhouse' THEN 10  WHEN 'lever'    THEN 10
+    WHEN 'usajobs'    THEN 10  WHEN 'linkedin' THEN 10
+    WHEN 'indeed'     THEN  9  WHEN 'remoteok' THEN  8
+    WHEN 'adzuna'     THEN  7  ELSE 4
+  END;
+
+  RETURN LEAST(100, v_title_score + v_recency + v_remote + v_salary + v_src);
+END;
+$$;
+
+COMMENT ON FUNCTION bridge_jobs_to_discovered IS
+  'Bridges job_postings (scraper) and scraped_jobs (discovery-agent) into '
+  'discovered_jobs (user-facing feed). Run every 30 min via pg_cron.';
+
+REVOKE EXECUTE ON FUNCTION bridge_jobs_to_discovered FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION bridge_jobs_to_discovered TO service_role;
+
+
+-- ---------------------------------------------------------------------------
+-- 5. pg_cron: run bridge every 30 minutes
+-- ---------------------------------------------------------------------------
+SELECT cron.schedule(
+  'bridge-jobs-to-discovered',
+  '*/30 * * * *',
+  $$SELECT bridge_jobs_to_discovered()$$
+);
+
+
+-- ---------------------------------------------------------------------------
+-- 6. Immediate backfill: run now so users see jobs without waiting
+--    Uses 30-day lookback so ALL existing scraper data is surfaced.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  r RECORD;
+  total_postings integer := 0;
+  total_scraped  integer := 0;
+BEGIN
+  FOR r IN SELECT * FROM bridge_jobs_to_discovered(NULL, 200, 720) LOOP
+    total_postings := total_postings + r.from_postings;
+    total_scraped  := total_scraped  + r.from_scraped;
+  END LOOP;
+  RAISE NOTICE 'Backfill complete: % from job_postings + % from scraped_jobs across all users',
+    total_postings, total_scraped;
+END;
+$$;

--- a/supabase/migrations/20260419_discovery_jobs_dedupe_constraint.sql
+++ b/supabase/migrations/20260419_discovery_jobs_dedupe_constraint.sql
@@ -1,0 +1,12 @@
+-- 20260419_discovery_jobs_dedupe_constraint.sql
+-- Replace partial unique index on discovery_jobs.dedupe_hash with a full unique
+-- constraint so that PostgREST ON CONFLICT (col) DO NOTHING works correctly.
+-- (PostgREST requires a non-partial, non-filtered unique index for the upsert
+--  onConflict path — a WHERE clause in the index definition breaks it.)
+
+-- Drop the partial index created in the initial migration
+DROP INDEX IF EXISTS discovery_jobs_dedupe_hash_idx;
+
+-- Add a proper full unique constraint
+ALTER TABLE discovery_jobs
+  ADD CONSTRAINT discovery_jobs_dedupe_hash_key UNIQUE (dedupe_hash);


### PR DESCRIPTION
## Release — 2026-04-20

Promotes three squashed fixes from `dev` to `main`.

---

### Included commits

| Commit | Change |
|---|---|
| bc40681 | chore: retire stale Supabase ref `gberhsbddthwkjimsqig` (#212) |
| 032e097 | fix(profile): hide `<UNKNOWN>` placeholder in location chip components (#211) |
| bea96b4 | fix(wiring): invoke edge functions from action buttons — Opportunity Radar, Autopilot, Flight Plan (#210) |

---

### What ships

**Edge function wiring (#207, #208)**
- Autopilot "Find & Queue Jobs": was calling disabled `search-jobs` via raw fetch → now `supabase.functions.invoke("discover-jobs")` with `job_queue` persistence
- Flight Plan "Generate Roadmap": raw fetch → `supabase.functions.invoke("career-path-analysis")`
- Opportunity Radar "Search Jobs": already correctly wired; added 4-state empty UI (idle / scanning / api-error / zero-matches)

**Location chip regression (#209)**
- `<UNKNOWN>` AI placeholder no longer renders as a chip on Autopilot Mode
- Filter applied at data-load boundary + render site

**Housekeeping**
- `supabase/config.toml` `project_id` updated to production ref
- `CLAUDE.md` added with canonical refs, branch policy, and invocation rules

---

### Backend verified

- `public.jobs`: 773 rows, ingestion healthy
- Edge functions `discover-jobs`, `career-path-analysis`, `match-jobs` ACTIVE
- TypeScript: 0 errors

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)