### PR TITLE
fix: replace remaining raw fetch calls with supabase.functions.invoke (#207 follow-up)

### DIFF
--- a/src/components/InterviewPredictor.tsx
+++ b/src/components/InterviewPredictor.tsx
@@ -39,19 +39,15 @@ export default function InterviewPredictor({ jobDescription, resumeText }: Inter
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) { toast.error("Please sign in"); return; }
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/interview-predictor`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ jobDescription: jobDescription.slice(0, 4000), resumeText: resumeText.slice(0, 4000) }),
+      const { data, error: fnErr } = await supabase.functions.invoke("interview-predictor", {
+        body: { jobDescription: jobDescription.slice(0, 4000), resumeText: resumeText.slice(0, 4000) },
       });
-
-      if (!resp.ok) {
-        if (resp.status === 429) { toast.error("Rate limit reached"); return; }
-        if (resp.status === 402) { toast.error("AI credits exhausted"); return; }
-        throw new Error("Failed");
+      if (fnErr) {
+        if (fnErr.message?.includes("429")) { toast.error("Rate limit reached"); return; }
+        if (fnErr.message?.includes("402")) { toast.error("AI credits exhausted"); return; }
+        throw new Error(fnErr.message ?? "Failed");
       }
-
-      const data = await resp.json();
+      if (!data) throw new Error("No data returned");
       setPredictions(data.questions || []);
       toast.success(`Generated ${data.questions?.length || 0} predicted questions`);
     } catch {
@@ -69,18 +65,15 @@ export default function InterviewPredictor({ jobDescription, resumeText }: Inter
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) return;
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/interview-predictor`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({
+      const { data, error: fnErr } = await supabase.functions.invoke("interview-predictor", {
+        body: {
           mode: "evaluate",
           question: predictions[idx].question,
           answer,
           jobDescription: jobDescription?.slice(0, 2000),
-        }),
+        },
       });
-      if (!resp.ok) throw new Error("Failed");
-      const data = await resp.json();
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Failed");
       setAnswerFeedback(prev => ({ ...prev, [idx]: data }));
     } catch {
       toast.error("Failed to evaluate");

--- a/src/components/LearningInsights.tsx
+++ b/src/components/LearningInsights.tsx
@@ -23,12 +23,8 @@ export default function LearningInsights() {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) return;
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/learning-insights`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-      });
-      if (!resp.ok) throw new Error("Failed");
-      const data = await resp.json();
+      const { data, error: fnErr } = await supabase.functions.invoke("learning-insights", { body: {} });
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Failed");
       setInsights(data.insights || []);
     } catch { toast.error("Failed to generate insights"); }
     finally { setLoading(false); }

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -83,14 +83,12 @@ export default function OnboardingWizard() {
       } as any);
 
       // Extract profile via edge function
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/extract-profile-fields`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ resumeText: result.text }),
+      const { data: extractData, error: fnErr } = await supabase.functions.invoke("extract-profile-fields", {
+        body: { resumeText: result.text },
       });
 
-      if (resp.ok) {
-        const { profile: extracted } = await resp.json();
+      if (!fnErr && extractData) {
+        const { profile: extracted } = extractData;
         const local = extractProfileFromResume(result.text);
         
         if (extracted) {

--- a/src/components/OutreachGenerator.tsx
+++ b/src/components/OutreachGenerator.tsx
@@ -30,14 +30,10 @@ export default function OutreachGenerator() {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) { toast.error("Please sign in"); return; }
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-outreach`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ company, role, contactName, messageType }),
+      const { data, error: fnErr } = await supabase.functions.invoke("generate-outreach", {
+        body: { company, role, contactName, messageType },
       });
-
-      if (!resp.ok) throw new Error("Failed");
-      const data = await resp.json();
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Failed");
       setResult(data.message || "");
     } catch { toast.error("Failed to generate message"); }
     finally { setGenerating(false); }

--- a/src/components/SalaryProjection.tsx
+++ b/src/components/SalaryProjection.tsx
@@ -44,18 +44,11 @@ export default function SalaryProjection({ skills, careerLevel, salaryMin, salar
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) { toast.error("Please sign in"); return; }
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/salary-projection`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ skills, careerLevel, salaryMin, salaryMax, salaryTarget, targetTitles, experience }),
+      const { data: result, error: fnErr } = await supabase.functions.invoke("salary-projection", {
+        body: { skills, careerLevel, salaryMin, salaryMax, salaryTarget, targetTitles, experience },
       });
-
-      if (!resp.ok) {
-        const err = await resp.json().catch(() => ({}));
-        throw new Error(err.error || "Failed to generate projection");
-      }
-
-      setData(await resp.json());
+      if (fnErr || !result) throw new Error(fnErr?.message ?? "Failed to generate projection");
+      setData(result);
     } catch (e: any) {
       toast.error(e.message || "Failed to generate salary projection");
     } finally {

--- a/src/components/career/OutreachGenerator.tsx
+++ b/src/components/career/OutreachGenerator.tsx
@@ -30,14 +30,10 @@ export default function OutreachGenerator() {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) { toast.error("Please sign in"); return; }
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-outreach`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ company, role, contactName, messageType }),
+      const { data, error: fnErr } = await supabase.functions.invoke("generate-outreach", {
+        body: { company, role, contactName, messageType },
       });
-
-      if (!resp.ok) throw new Error("Failed");
-      const data = await resp.json();
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Failed");
       setResult(data.message || "");
     } catch { toast.error("Failed to generate message"); }
     finally { setGenerating(false); }

--- a/src/components/career/SalaryProjection.tsx
+++ b/src/components/career/SalaryProjection.tsx
@@ -44,18 +44,11 @@ export default function SalaryProjection({ skills, careerLevel, salaryMin, salar
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) { toast.error("Please sign in"); return; }
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/salary-projection`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ skills, careerLevel, salaryMin, salaryMax, salaryTarget, targetTitles, experience }),
+      const { data: result, error: fnErr } = await supabase.functions.invoke("salary-projection", {
+        body: { skills, careerLevel, salaryMin, salaryMax, salaryTarget, targetTitles, experience },
       });
-
-      if (!resp.ok) {
-        const err = await resp.json().catch(() => ({}));
-        throw new Error(err.error || "Failed to generate projection");
-      }
-
-      setData(await resp.json());
+      if (fnErr || !result) throw new Error(fnErr?.message ?? "Failed to generate projection");
+      setData(result);
     } catch (e: any) {
       toast.error(e.message || "Failed to generate salary projection");
     } finally {

--- a/src/components/dashboard/LearningInsights.tsx
+++ b/src/components/dashboard/LearningInsights.tsx
@@ -23,12 +23,8 @@ export default function LearningInsights() {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) return;
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/learning-insights`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-      });
-      if (!resp.ok) throw new Error("Failed");
-      const data = await resp.json();
+      const { data, error: fnErr } = await supabase.functions.invoke("learning-insights", { body: {} });
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Failed");
       setInsights(data.insights || []);
     } catch { toast.error("Failed to generate insights"); }
     finally { setLoading(false); }

--- a/src/components/dashboard/OnboardingWizard.tsx
+++ b/src/components/dashboard/OnboardingWizard.tsx
@@ -83,14 +83,12 @@ export default function OnboardingWizard() {
       } as any);
 
       // Extract profile via edge function
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/extract-profile-fields`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ resumeText: result.text }),
+      const { data: extractData, error: fnErr } = await supabase.functions.invoke("extract-profile-fields", {
+        body: { resumeText: result.text },
       });
 
-      if (resp.ok) {
-        const { profile: extracted } = await resp.json();
+      if (!fnErr && extractData) {
+        const { profile: extracted } = extractData;
         const local = extractProfileFromResume(result.text);
         
         if (extracted) {

--- a/src/components/job-seeker/InterviewPredictor.tsx
+++ b/src/components/job-seeker/InterviewPredictor.tsx
@@ -39,19 +39,15 @@ export default function InterviewPredictor({ jobDescription, resumeText }: Inter
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) { toast.error("Please sign in"); return; }
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/interview-predictor`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ jobDescription: jobDescription.slice(0, 4000), resumeText: resumeText.slice(0, 4000) }),
+      const { data, error: fnErr } = await supabase.functions.invoke("interview-predictor", {
+        body: { jobDescription: jobDescription.slice(0, 4000), resumeText: resumeText.slice(0, 4000) },
       });
-
-      if (!resp.ok) {
-        if (resp.status === 429) { toast.error("Rate limit reached"); return; }
-        if (resp.status === 402) { toast.error("AI credits exhausted"); return; }
-        throw new Error("Failed");
+      if (fnErr) {
+        if (fnErr.message?.includes("429")) { toast.error("Rate limit reached"); return; }
+        if (fnErr.message?.includes("402")) { toast.error("AI credits exhausted"); return; }
+        throw new Error(fnErr.message ?? "Failed");
       }
-
-      const data = await resp.json();
+      if (!data) throw new Error("No data returned");
       setPredictions(data.questions || []);
       toast.success(`Generated ${data.questions?.length || 0} predicted questions`);
     } catch {
@@ -69,18 +65,15 @@ export default function InterviewPredictor({ jobDescription, resumeText }: Inter
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) return;
 
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/interview-predictor`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({
+      const { data, error: fnErr } = await supabase.functions.invoke("interview-predictor", {
+        body: {
           mode: "evaluate",
           question: predictions[idx].question,
           answer,
           jobDescription: jobDescription?.slice(0, 2000),
-        }),
+        },
       });
-      if (!resp.ok) throw new Error("Failed");
-      const data = await resp.json();
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Failed");
       setAnswerFeedback(prev => ({ ...prev, [idx]: data }));
     } catch {
       toast.error("Failed to evaluate");

--- a/src/components/profile/ProfileForm.tsx
+++ b/src/components/profile/ProfileForm.tsx
@@ -219,13 +219,11 @@ export default function ProfileForm({ profile, setProfile, onSave, saving }: Pro
     try {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) { toast.error("Please sign in"); return; }
-      const resp = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/extract-profile-fields`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ resumeText: `Skills: ${profile.skills.join(", ")}. Experience: ${profile.work_experience.map(w => `${w.title} at ${w.company}`).join("; ")}` }),
+      const { data: extractData, error: fnErr } = await supabase.functions.invoke("extract-profile-fields", {
+        body: { resumeText: `Skills: ${profile.skills.join(", ")}. Experience: ${profile.work_experience.map(w => `${w.title} at ${w.company}`).join("; ")}` },
       });
-      if (!resp.ok) throw new Error("Failed");
-      const { profile: extracted } = await resp.json();
+      if (fnErr || !extractData) throw new Error(fnErr?.message ?? "Failed");
+      const { profile: extracted } = extractData;
       if (extracted?.target_job_titles?.length || extracted?.job_titles?.length) {
         const suggestions = (extracted.target_job_titles || extracted.job_titles || []).filter((t: string) => !profile.target_job_titles.includes(t));
         if (suggestions.length > 0) {
@@ -256,22 +254,12 @@ export default function ProfileForm({ profile, setProfile, onSave, saving }: Pro
       let extracted: any = null;
       try {
         const { data: { session } } = await supabase.auth.getSession();
-        const token = session?.access_token;
-        if (token) {
-          const resp = await fetch(
-            `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/extract-profile-fields`,
-            {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
-              },
-              body: JSON.stringify({ resumeText: result.text }),
-            }
-          );
-          if (resp.ok) {
-            const data = await resp.json();
-            extracted = data.profile;
+        if (session) {
+          const { data: extractData, error: fnErr } = await supabase.functions.invoke("extract-profile-fields", {
+            body: { resumeText: result.text },
+          });
+          if (!fnErr && extractData) {
+            extracted = extractData.profile;
           }
         }
       } catch (aiErr) {


### PR DESCRIPTION
## Summary

Follow-up to PRs #210 and #211. Converts the last 6 components still using raw \`fetch(VITE_SUPABASE_URL/functions/v1/...)\` to \`supabase.functions.invoke()\`, completing the systemic wiring fix for Issue #207.

**Components fixed:**
- OutreachGenerator — generate-outreach
- SalaryProjection — salary-projection
- LearningInsights — learning-insights
- InterviewPredictor — interview-predictor (predict + evaluate flows)
- OnboardingWizard — extract-profile-fields
- ProfileForm — extract-profile-fields (suggestTitles + handleImportResume)

Each canonical was synced to its top-level duplicate under src/components/.

## Why

Raw fetch() bypasses Supabase SDK auth injection. Edge functions without a valid Authorization header return 401s silently. supabase.functions.invoke() automatically attaches the session JWT.

## Test plan

- [ ] Generate Outreach Message on Career page
- [ ] Generate Salary Projection on Career page
- [ ] Generate Learning Insights on Dashboard
- [ ] Predict Interview Questions on a job card
- [ ] Evaluate an answer in Interview Predictor
- [ ] Upload resume through Onboarding Wizard
- [ ] Upload resume via Profile page
- [ ] AI Suggest titles button on Profile page

Generated with Claude (Cowork)