### PR TITLE
fix: complete raw-fetch sweep — final (v4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,13 @@ Exception: SSE streaming responses (e.g. `mock-interview`) require raw fetch wit
 
 ## Active Edge Functions (verified 2026-04-20)
 
-`discover-jobs`, `career-path-analysis`, `match-jobs`, `discovery-agent`, `search-jobs`
+`discover-jobs`, `career-path-analysis`, `match-jobs`, `discovery-agent`, `search-jobs`,
+`generate-outreach`, `salary-projection`, `learning-insights`, `interview-predictor`,
+`extract-profile-fields`, `rewrite-resume`, `generate-cover-letter`,
+`generate-interview-prep`, `generate-followup-email`, `recruiter-assistant`
+
+SSE streaming (raw fetch exception): `mock-interview`, `rewrite-resume`, `generate-cover-letter`,
+`generate-interview-prep`, `generate-followup-email`, `recruiter-assistant`
 
 ## Never
 

--- a/src/components/CareerPathIntelligence.tsx
+++ b/src/components/CareerPathIntelligence.tsx
@@ -44,28 +44,18 @@ export default function CareerPathIntelligence() {
         .order("created_at", { ascending: false })
         .limit(5) as any;
 
-      const resp = await fetch(
-        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/career-path-analysis`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${session.access_token}`,
-          },
-          body: JSON.stringify({
-            skills: profile.skills,
-            careerLevel: (profile as any).career_level,
-            experience: profile.work_experience,
-            education: profile.education,
-            certifications: profile.certifications,
-            targetTitles: (profile as any).target_job_titles,
-            recentAnalyses: history || [],
-          }),
-        }
-      );
-
-      if (!resp.ok) throw new Error("Analysis failed");
-      const data = await resp.json();
+      const { data, error: fnErr } = await supabase.functions.invoke("career-path-analysis", {
+        body: {
+          skills: profile.skills,
+          careerLevel: (profile as any).career_level,
+          experience: profile.work_experience,
+          education: profile.education,
+          certifications: profile.certifications,
+          targetTitles: (profile as any).target_job_titles,
+          recentAnalyses: history || [],
+        },
+      });
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Analysis failed");
       setInsight(data);
     } catch {
       toast.error("Failed to analyze career path");

--- a/src/components/RecruiterAssistant.tsx
+++ b/src/components/RecruiterAssistant.tsx
@@ -45,6 +45,7 @@ export default function RecruiterAssistant() {
         .eq("user_id", session.user.id)
         .maybeSingle();
 
+      // SSE streaming — raw fetch is intentional; invoke() does not support streaming
       const resp = await fetch(
         `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/recruiter-assistant`,
         {

--- a/src/components/dashboard/CareerPathIntelligence.tsx
+++ b/src/components/dashboard/CareerPathIntelligence.tsx
@@ -44,28 +44,18 @@ export default function CareerPathIntelligence() {
         .order("created_at", { ascending: false })
         .limit(5) as any;
 
-      const resp = await fetch(
-        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/career-path-analysis`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${session.access_token}`,
-          },
-          body: JSON.stringify({
-            skills: profile.skills,
-            careerLevel: (profile as any).career_level,
-            experience: profile.work_experience,
-            education: profile.education,
-            certifications: profile.certifications,
-            targetTitles: (profile as any).target_job_titles,
-            recentAnalyses: history || [],
-          }),
-        }
-      );
-
-      if (!resp.ok) throw new Error("Analysis failed");
-      const data = await resp.json();
+      const { data, error: fnErr } = await supabase.functions.invoke("career-path-analysis", {
+        body: {
+          skills: profile.skills,
+          careerLevel: (profile as any).career_level,
+          experience: profile.work_experience,
+          education: profile.education,
+          certifications: profile.certifications,
+          targetTitles: (profile as any).target_job_titles,
+          recentAnalyses: history || [],
+        },
+      });
+      if (fnErr || !data) throw new Error(fnErr?.message ?? "Analysis failed");
       setInsight(data);
     } catch {
       toast.error("Failed to analyze career path");

--- a/src/components/hiring-manager/RecruiterAssistant.tsx
+++ b/src/components/hiring-manager/RecruiterAssistant.tsx
@@ -45,6 +45,7 @@ export default function RecruiterAssistant() {
         .eq("user_id", session.user.id)
         .maybeSingle();
 
+      // SSE streaming — raw fetch is intentional; invoke() does not support streaming
       const resp = await fetch(
         `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/recruiter-assistant`,
         {

--- a/src/components/job-seeker/AnalysisResults.tsx
+++ b/src/components/job-seeker/AnalysisResults.tsx
@@ -76,6 +76,12 @@ export default function AnalysisResults({
   const [addingSkill, setAddingSkill] = useState<string | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
 
+  /**
+   * SSE streaming helper — raw fetch is intentional.
+   * supabase.functions.invoke() does not support streaming responses.
+   * All callers of this helper target streaming edge functions:
+   * rewrite-resume, generate-cover-letter, generate-interview-prep, generate-followup-email.
+   */
   const streamFromEdgeFunction = async (
     functionName: string, body: Record<string, any>,
     onChunk: (text: string) => void, onDone?: () => void,


### PR DESCRIPTION
## Summary

Finishes the raw-fetch → supabase.functions.invoke() sweep started in PRs #210–#214.

**CareerPathIntelligence** (canonical + top-level dup):
- Converted raw fetch(career-path-analysis) to supabase.functions.invoke()

**RecruiterAssistant** (canonical + top-level dup):
- Verified genuine SSE streaming — NOT converted (documented exception)
- Added SSE comment to make intent explicit for future agents

**AnalysisResults**:
- Verified all 4 streaming functions (rewrite-resume, generate-cover-letter, generate-interview-prep, generate-followup-email) — NOT converted
- Added JSDoc block comment on streamFromEdgeFunction helper

**CLAUDE.md**: expanded active edge function list; SSE exceptions explicitly listed.

## Done criteria
- [x] CareerPathIntelligence uses invoke() — no raw fetch
- [x] Top-level dup synced
- [x] RecruiterAssistant has SSE comment — not converted
- [x] Top-level dup synced
- [x] AnalysisResults has SSE block comment — not converted
- [x] `grep -r "VITE_SUPABASE_URL" src/components/` returns only SSE-commented hits
- [x] CLAUDE.md updated

Generated with Claude (Cowork)