### PR TITLE
refactor: add useAgentInvocation() hook, migrate 5 components

### DIFF
--- a/src/components/GapIntelligence.tsx
+++ b/src/components/GapIntelligence.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { AlertTriangle, TrendingUp, Shield, Zap, ChevronDown, ChevronUp, Target, Loader2, Wrench, Plus, Check } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import { useAgentInvocation } from "@/hooks/useAgentInvocation";
 import type { FitAnalysis } from "@/lib/analysisEngine";
 
 interface GapIntelligenceProps {
@@ -35,27 +36,17 @@ function getImpactRank(gap: { area: string; severity: string }, index: number): 
 
 export default function GapIntelligence({ analysis, onFixAll, onReEvaluate }: GapIntelligenceProps) {
   const [expanded, setExpanded] = useState(false);
-  const [fixingAll, setFixingAll] = useState(false);
   const [addingSkills, setAddingSkills] = useState(false);
   const [addedSkills, setAddedSkills] = useState<string[]>([]);
+  const { invoke: invokeOrchestrator, loading: fixingAll } = useAgentInvocation(
+    "agent-orchestrator",
+    { errorMessage: "Failed to launch agent" }
+  );
 
   const handleFixAll = async () => {
-    setFixingAll(true);
-    try {
-      if (onFixAll) {
-        onFixAll();
-      } else {
-        const { data, error } = await supabase.functions.invoke("agent-orchestrator", {
-          body: { agents: ["optimization", "application"] },
-        });
-        if (error) throw error;
-        toast.success("Agent launched! Optimizing your resume and targeting gaps.");
-      }
-    } catch (e: any) {
-      toast.error(e.message || "Failed to launch agent");
-    } finally {
-      setFixingAll(false);
-    }
+    if (onFixAll) { onFixAll(); return; }
+    const data = await invokeOrchestrator({ agents: ["optimization", "application"] });
+    if (data !== null) toast.success("Agent launched! Optimizing your resume and targeting gaps.");
   };
 
   const handleAddGapsToProfile = async () => {

--- a/src/components/RejectionSimulator.tsx
+++ b/src/components/RejectionSimulator.tsx
@@ -4,10 +4,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { Loader2, ShieldAlert, Eye, CheckCircle2, XCircle, AlertTriangle, Zap } from "lucide-react";
-import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { Progress } from "@/components/ui/progress";
-import { logger } from '@/lib/logger';
+import { useAgentInvocation } from "@/hooks/useAgentInvocation";
 
 interface SimulationResult {
   ats_stage: {
@@ -44,7 +43,9 @@ interface Props {
 export default function RejectionSimulator({ resumeText: initialResume, jobDescription: initialJd, jobTitle }: Props) {
   const [resumeText, setResumeText] = useState(initialResume || "");
   const [jobDescription, setJobDescription] = useState(initialJd || "");
-  const [loading, setLoading] = useState(false);
+  const { invoke, loading } = useAgentInvocation<SimulationResult>("simulate-rejection", {
+    errorMessage: "Simulation failed",
+  });
   const [result, setResult] = useState<SimulationResult | null>(null);
 
   const runSimulation = async () => {
@@ -52,19 +53,8 @@ export default function RejectionSimulator({ resumeText: initialResume, jobDescr
       toast.error("Both resume and job description are required");
       return;
     }
-    setLoading(true);
-    try {
-      const { data, error } = await supabase.functions.invoke("simulate-rejection", {
-        body: { resumeText, jobDescription, jobTitle },
-      });
-      if (error) throw error;
-      setResult(data);
-    } catch (e) {
-      toast.error("Simulation failed");
-      logger.error(e);
-    } finally {
-      setLoading(false);
-    }
+    const data = await invoke({ resumeText, jobDescription, jobTitle });
+    if (data) setResult(data);
   };
 
   const priorityColor = (p: string) => {

--- a/src/components/hiring-manager/JobPostingForm.tsx
+++ b/src/components/hiring-manager/JobPostingForm.tsx
@@ -9,6 +9,7 @@ import {
 import { Loader2, ArrowRight, ArrowLeft, Sparkles } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import { useAgentInvocation } from "@/hooks/useAgentInvocation";
 import SkillsTagInput from "./SkillsTagInput";
 import JobPostingPreview from "./JobPostingPreview";
 
@@ -54,7 +55,14 @@ export default function JobPostingForm({ editing, onSaved, onCancel }: Props) {
   const [form, setForm] = useState<JobPostingFormData>(editing || EMPTY_FORM);
   const [step, setStep] = useState(1);
   const [saving, setSaving] = useState(false);
-  const [generating, setGenerating] = useState(false);
+  const { invoke: generateJobPosting, loading: generating } = useAgentInvocation<{
+    title?: string;
+    description?: string;
+    requirements?: string;
+    nice_to_haves?: string;
+    salary_suggestion_min?: number;
+    salary_suggestion_max?: number;
+  }>("generate-job-posting", { errorMessage: "AI generation failed" });
 
   // Load draft from localStorage on mount (only for new postings)
   useEffect(() => {
@@ -102,28 +110,18 @@ export default function JobPostingForm({ editing, onSaved, onCancel }: Props) {
 
   const handleAIGenerate = async () => {
     if (!form.title.trim()) { toast.error("Enter a job title first"); return; }
-    setGenerating(true);
-    try {
-      const { data, error } = await supabase.functions.invoke("generate-job-posting", {
-        body: { title: form.title, company: form.company, department: "" },
-      });
-      if (error) throw error;
-      if (data?.error) throw new Error(data.error);
-      setForm((prev) => ({
-        ...prev,
-        title: data.title || prev.title,
-        description: data.description || prev.description,
-        requirements: data.requirements || prev.requirements,
-        niceToHaves: data.nice_to_haves || prev.niceToHaves,
-        salaryMin: data.salary_suggestion_min ? String(data.salary_suggestion_min) : prev.salaryMin,
-        salaryMax: data.salary_suggestion_max ? String(data.salary_suggestion_max) : prev.salaryMax,
-      }));
-      toast.success("AI generated your job posting!");
-    } catch (e: any) {
-      toast.error(e.message || "AI generation failed");
-    } finally {
-      setGenerating(false);
-    }
+    const data = await generateJobPosting({ title: form.title, company: form.company, department: "" });
+    if (!data) return;
+    setForm((prev) => ({
+      ...prev,
+      title: data.title || prev.title,
+      description: data.description || prev.description,
+      requirements: data.requirements || prev.requirements,
+      niceToHaves: data.nice_to_haves || prev.niceToHaves,
+      salaryMin: data.salary_suggestion_min ? String(data.salary_suggestion_min) : prev.salaryMin,
+      salaryMax: data.salary_suggestion_max ? String(data.salary_suggestion_max) : prev.salaryMax,
+    }));
+    toast.success("AI generated your job posting!");
   };
 
   const handleSubmit = async (asDraft = false) => {

--- a/src/components/interview/RejectionSimulator.tsx
+++ b/src/components/interview/RejectionSimulator.tsx
@@ -4,10 +4,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { Loader2, ShieldAlert, Eye, CheckCircle2, XCircle, AlertTriangle, Zap } from "lucide-react";
-import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { Progress } from "@/components/ui/progress";
-import { logger } from '@/lib/logger';
+import { useAgentInvocation } from "@/hooks/useAgentInvocation";
 
 interface SimulationResult {
   ats_stage: {
@@ -44,7 +43,9 @@ interface Props {
 export default function RejectionSimulator({ resumeText: initialResume, jobDescription: initialJd, jobTitle }: Props) {
   const [resumeText, setResumeText] = useState(initialResume || "");
   const [jobDescription, setJobDescription] = useState(initialJd || "");
-  const [loading, setLoading] = useState(false);
+  const { invoke, loading } = useAgentInvocation<SimulationResult>("simulate-rejection", {
+    errorMessage: "Simulation failed",
+  });
   const [result, setResult] = useState<SimulationResult | null>(null);
 
   const runSimulation = async () => {
@@ -52,19 +53,8 @@ export default function RejectionSimulator({ resumeText: initialResume, jobDescr
       toast.error("Both resume and job description are required");
       return;
     }
-    setLoading(true);
-    try {
-      const { data, error } = await supabase.functions.invoke("simulate-rejection", {
-        body: { resumeText, jobDescription, jobTitle },
-      });
-      if (error) throw error;
-      setResult(data);
-    } catch (e) {
-      toast.error("Simulation failed");
-      logger.error(e);
-    } finally {
-      setLoading(false);
-    }
+    const data = await invoke({ resumeText, jobDescription, jobTitle });
+    if (data) setResult(data);
   };
 
   const priorityColor = (p: string) => {

--- a/src/components/job-seeker/GapIntelligence.tsx
+++ b/src/components/job-seeker/GapIntelligence.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { AlertTriangle, TrendingUp, Shield, Zap, ChevronDown, ChevronUp, Target, Loader2, Wrench, Plus, Check } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import { useAgentInvocation } from "@/hooks/useAgentInvocation";
 import type { FitAnalysis } from "@/lib/analysisEngine";
 
 interface GapIntelligenceProps {
@@ -35,27 +36,17 @@ function getImpactRank(gap: { area: string; severity: string }, index: number): 
 
 export default function GapIntelligence({ analysis, onFixAll, onReEvaluate }: GapIntelligenceProps) {
   const [expanded, setExpanded] = useState(false);
-  const [fixingAll, setFixingAll] = useState(false);
   const [addingSkills, setAddingSkills] = useState(false);
   const [addedSkills, setAddedSkills] = useState<string[]>([]);
+  const { invoke: invokeOrchestrator, loading: fixingAll } = useAgentInvocation(
+    "agent-orchestrator",
+    { errorMessage: "Failed to launch agent" }
+  );
 
   const handleFixAll = async () => {
-    setFixingAll(true);
-    try {
-      if (onFixAll) {
-        onFixAll();
-      } else {
-        const { data, error } = await supabase.functions.invoke("agent-orchestrator", {
-          body: { agents: ["optimization", "application"] },
-        });
-        if (error) throw error;
-        toast.success("Agent launched! Optimizing your resume and targeting gaps.");
-      }
-    } catch (e: any) {
-      toast.error(e.message || "Failed to launch agent");
-    } finally {
-      setFixingAll(false);
-    }
+    if (onFixAll) { onFixAll(); return; }
+    const data = await invokeOrchestrator({ agents: ["optimization", "application"] });
+    if (data !== null) toast.success("Agent launched! Optimizing your resume and targeting gaps.");
   };
 
   const handleAddGapsToProfile = async () => {

--- a/src/hooks/useAgentInvocation.ts
+++ b/src/hooks/useAgentInvocation.ts
@@ -1,0 +1,82 @@
+import { useState, useCallback } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
+
+interface UseAgentInvocationOptions {
+  /**
+   * Toast message shown to the user on failure.
+   * If omitted, the hook stores the error in `error` state but shows no toast.
+   */
+  errorMessage?: string;
+}
+
+interface UseAgentInvocationReturn<T> {
+  /** Call the edge function with the given body. Returns data on success, null on failure. */
+  invoke: (body?: Record<string, unknown>) => Promise<T | null>;
+  /** True while the request is in-flight. */
+  loading: boolean;
+  /** Error message from the last failed call, or null. */
+  error: string | null;
+  /** Clear the error state. */
+  reset: () => void;
+}
+
+/**
+ * Centralised wrapper for supabase.functions.invoke().
+ *
+ * Manages loading/error state and optionally shows a toast on failure.
+ * Catches both Supabase-level errors and application-level errors embedded
+ * in the response body (data.error).
+ *
+ * Usage:
+ *   const { invoke, loading } = useAgentInvocation<MyResponseType>(
+ *     "my-edge-function",
+ *     { errorMessage: "Something went wrong" }
+ *   );
+ *   const data = await invoke({ key: value });
+ *   if (data) { ... }
+ *
+ * NOTE: SSE streaming responses (e.g. mock-interview) require raw fetch()
+ * with resp.body?.getReader() and are intentionally NOT covered by this hook.
+ */
+export function useAgentInvocation<T = unknown>(
+  fnName: string,
+  options: UseAgentInvocationOptions = {}
+): UseAgentInvocationReturn<T> {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => setError(null), []);
+
+  const invoke = useCallback(
+    async (body?: Record<string, unknown>): Promise<T | null> => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error: fnErr } = await supabase.functions.invoke(fnName, { body });
+
+        if (fnErr) throw new Error(fnErr.message || `${fnName} failed`);
+        if ((data as Record<string, unknown>)?.error) {
+          throw new Error(String((data as Record<string, unknown>).error));
+        }
+
+        return data as T;
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : `${fnName} failed`;
+        setError(msg);
+        if (options.errorMessage !== undefined) {
+          const description = msg !== options.errorMessage ? msg : undefined;
+          toast.error(options.errorMessage, { description });
+        }
+        return null;
+      } finally {
+        setLoading(false);
+      }
+    },
+    // fnName is stable across renders; options.errorMessage is a primitive.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [fnName, options.errorMessage]
+  );
+
+  return { invoke, loading, error, reset };
+}


### PR DESCRIPTION
## Summary

Introduces a shared `useAgentInvocation()` hook that centralizes all `supabase.functions.invoke()` calls, loading state, and error handling — eliminating repeated boilerplate across components.

### Hook design (`src/hooks/useAgentInvocation.ts`)
- Generic `<T>` return type for typed responses
- Manages `loading` and `error` state internally
- Catches both Supabase-level errors (`fnErr`) and app-level `data.error` strings
- Optional `errorMessage` option controls whether `toast.error()` fires on failure
- Exports `{ invoke, loading, error, reset }`

### Components migrated (5 files)
| File | Edge Function |
|---|---|
| `src/hooks/useAgentInvocation.ts` | *(new file)* |
| `src/components/hiring-manager/JobPostingForm.tsx` | `generate-job-posting` |
| `src/components/job-seeker/GapIntelligence.tsx` | `agent-orchestrator` |
| `src/components/GapIntelligence.tsx` | `agent-orchestrator` |
| `src/components/interview/RejectionSimulator.tsx` | `simulate-rejection` |
| `src/components/RejectionSimulator.tsx` | `simulate-rejection` |

### Intentionally NOT migrated
- `AnalysisResults.tsx` — uses SSE streaming via raw `fetch()` + `ReadableStream` (mock-interview), which is incompatible with the hook pattern
- Components with multiple per-operation loading states or complex fallback chains that benefit from explicit control

## Test plan
- [ ] Job posting AI generate still populates fields
- [ ] Gap intelligence "Fix All Gaps" still launches agent
- [ ] Rejection simulator still runs and shows results
- [ ] All `loading` states correctly show spinners during invocation
- [ ] Failed invocations show toast errors as before