### PR TITLE
fix: skip Husky in CI by setting HUSKY=0 during bun install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+        env:
+          HUSKY: 0
 
       - name: Type check
         run: bun run tsc --noEmit


### PR DESCRIPTION
The prepare script runs `husky` which fails in GitHub Actions because the git hooks environment isn't available. Setting HUSKY=0 disables the init step so the install and all subsequent CI steps can proceed.