### PR TITLE
fix(agent-orchestrator): runApplication writes 0, not daily budget remaining

### DIFF
--- a/supabase/functions/agent-orchestrator/index.ts
+++ b/supabase/functions/agent-orchestrator/index.ts
@@ -234,7 +234,7 @@ async function runApplication(ctx: AgentContext): Promise<AgentResult> {
   return {
     name: "application",
     success: true,
-    metrics: { applications_sent: remaining },
+    metrics: { applications_sent: 0 },
   };
 }
 


### PR DESCRIPTION
## Summary

`runApplication()` is a stub — it never actually inserts into `job_applications`. It was returning `(dailyCap - count_today)` as `applications_sent`, i.e. the remaining daily budget, not a count of actual sends. This caused impossible Mission Control states like "0 found · 0 matched · 10 applied".

This PR changes the return to `applications_sent: 0` — honest until the real auto-apply flow is implemented.

## Change

Single-file, one-line change in `supabase/functions/agent-orchestrator/index.ts`:
- Before: `metrics: { applications_sent: remaining }`
- After:  `metrics: { applications_sent: 0 }`

The `remaining` variable on the preceding line is now dead code. ESLint may flag it as unused; not fixing in this PR to keep the diff minimal and focused.

## Related migrations

- Already shipped: `20260423a_backfill_agent_runs_applications_sent` — reconciled historical rows so Mission Control numbers are truthful right now
- Ready to apply after this PR merges: `20260423b_add_agent_runs_check_constraint` — adds `CHECK (applications_sent <= jobs_matched <= jobs_found)` to prevent regressions

## Follow-ups (not in this PR)

- Dead-code cleanup of the `remaining` variable and surrounding `pgCount` call
- Architectural fix in `runMatching()`: it queries `scraped_jobs` globally instead of using `runDiscovery()`'s output, which is how rows with `jobs_matched > jobs_found` occurred
- Actually implement the auto-apply flow (separate product decision)
