### PR TITLE
fix(agent-orchestrator): runMatching reads job_postings, not missing scraped_jobs

### DIFF
--- a/supabase/functions/agent-orchestrator/index.ts
+++ b/supabase/functions/agent-orchestrator/index.ts
@@ -155,7 +155,7 @@ async function runMatching(ctx: AgentContext): Promise<AgentResult> {
     return { name: "matching", success: true, metrics: { jobs_matched: 0 } };
 
   const jobs = await pgGet(
-    "scraped_jobs",
+    "job_postings",
     "select=id,title,company,description&order=created_at.desc&limit=30",
   );
   if (!jobs?.length)


### PR DESCRIPTION
## Summary

`runMatching()` was calling `pgGet("scraped_jobs", ...)`. The `scraped_jobs` table does not exist in the production schema. The `pgGet` call silently errored under `withRetry()`'s catch-all and returned an empty list — which is why agent runs produce `jobs_matched: 0` even when the pipeline has fresh jobs available.

## Production table evidence (queried 2026-04-24)

| Table | Rows | Most recent write | Notes |
|---|---|---|---|
| `job_postings` | 19,115 | 2h ago | Live pipeline output |
| `jobs` | 1,354 | 4h ago | Secondary/legacy |
| `discovery_jobs` | 30 | 5d ago | Discovery stage |
| `discovered_jobs` | 3 | 12d ago | Stale/dead |
| `scraped_jobs` | — | — | **Does not exist** |

## Change

Single-line change in `supabase/functions/agent-orchestrator/index.ts`:

- Before: `await pgGet("scraped_jobs", "select=id,title,company,description&order=created_at.desc&limit=30")`
- After:  `await pgGet("job_postings", "select=id,title,company,description&order=created_at.desc&limit=30")`

The `job_postings` schema matches exactly for the columns selected (`id, title, company, description, created_at`).

## Follow-ups (not in this PR)

- `runMatching()` still queries globally (top 30 by recency across all jobs) instead of using `runDiscovery()`'s output. Architectural improvement — thread discovery's returned job IDs into matching as a parameter.
- Consider adding a `status=eq.active` filter to avoid matching against archived postings.
- Repo-wide grep recommended for other stale references to `scraped_jobs` from the same refactor.
