### PR TITLE
fix(search-jobs): remove broken careerLevel→title ILIKE filter

### DIFF
--- a/supabase/functions/search-jobs/index.ts
+++ b/supabase/functions/search-jobs/index.ts
@@ -245,8 +245,6 @@ async function queryJobPostings(
   if (params.isRemote === true) query = query.eq("is_remote", true);
   if (params.jobType) query = query.eq("job_type", params.jobType);
   if (params.salaryMin) query = query.gte("salary_max", params.salaryMin);
-  if (params.careerLevel)
-    query = query.ilike("title", `%${params.careerLevel}%`);
 
   const cutoff = new Date(
     Date.now() - (params.daysOld ?? 30) * 24 * 60 * 60 * 1000,


### PR DESCRIPTION
careerLevel from job_seeker_profiles holds self-described seniority labels like "VP / Senior Leadership" that don't appear in real job titles. Removes hard filter, keeps career-level signal only in calculateInlineScore soft boost. Diagnosed via SQL: 0 of 19,158 jobs matched with hard filter in place.